### PR TITLE
Remove index date from search web

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import router from "./routes/routes";
 import {ERROR_SUMMARY_TITLE} from "./model/error.messages";
 import errorHandlers from "./controllers/error.controller";
-import {PIWIK_SITE_ID, PIWIK_URL, INDEX_DATE} from "./config/config";
+import {PIWIK_SITE_ID, PIWIK_URL} from "./config/config";
 
 const app = express();
 
@@ -32,7 +32,6 @@ env.addGlobal("ERROR_SUMMARY_TITLE", ERROR_SUMMARY_TITLE);
 env.addGlobal("PIWIK_URL", PIWIK_URL);
 env.addGlobal("PIWIK_SITE_ID", PIWIK_SITE_ID);
 env.addGlobal("CDN_URL", process.env.CDN_HOST);
-env.addGlobal("INDEX_DATE", INDEX_DATE);
 
 // serve static assets in development.
 // this will execute in production for now, but we will host these else where in the future.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,7 +10,6 @@ const getEnvironmentValue = (key: string, defaultValue?: any): string => {
 };
 
 export const ALPHABETICAL_SEARCH_URL = getEnvironmentValue("ALPHABETICAL_SEARCH_URL");
-export const INDEX_DATE = getEnvironmentValue("INDEX_DATE");
 export const CHS_API_KEY = getEnvironmentValue("CHS_API_KEY");
 export const SEARCH_WEB_COOKIE_NAME = getEnvironmentValue("SEARCH_WEB_COOKIE_NAME");
 export const PIWIK_URL = getEnvironmentValue("PIWIK_URL");

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,5 @@
 export default async () => {
   process.env.ALPHABETICAL_SEARCH_URL = "http://localhost:4089/alphabetical-search/corporate-body";
-  process.env.INDEX_DATE = "01 January 2020";
   process.env.CHS_API_KEY = "testauthkey";
   process.env.SEARCH_WEB_COOKIE_NAME = "search.web.user";
   process.env.PIWIK_URL = "test";

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -6,9 +6,6 @@
     <h1 class="govuk-heading-xl">
       Alphabetical company search
     </h1>
-    <p class="govuk-body">
-      Search the register and get alphabetical results up to {{ INDEX_DATE }}
-    </p>
     <form action="/alphabetical-search/get-results" method="GET">
       {{ govukInput({
         id: "companyName",


### PR DESCRIPTION
Remove the index date as it is no longer required with the release of the consumer - which will keep the index up to date where as previously only companies would be present up until the date the alphabetical search instance was indexed. 

Resolves: GCI-991