### PR TITLE
Add accessibility statement link to search web

### DIFF
--- a/src/views/base.html
+++ b/src/views/base.html
@@ -49,6 +49,10 @@
             text: "Contact us"
           },
           {
+            href: "/help/accessibility-statement",
+            text: "Accessibility statement"
+          },
+          {
             href: "https://developer.companieshouse.gov.uk/api/docs/",
             text: "Developers"
           }


### PR DESCRIPTION
Alphabetical search is directly accessible from CHS and has the insights footer. Therefore this needs to be added.

Resolves: CB-1108