### PR TITLE
Bi 7347 add functionality to alpha search checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -338,9 +338,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.22.tgz",
-      "integrity": "sha512-xJwqzhISZAd0LL7+JI8eWpLjOWJQgQbjo2hogl8p7wQ6w/o36NjkRdVnsCJfBrQuJnk0lio364qewouU7SSnvA==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.23.tgz",
+      "integrity": "sha512-norW+KXcLEJANqH8ilvPFElFHSNAa78fo9QkdqGfFLb4RKtYZNntyQjCgnbFXkv9X3j4nhbaYh7/5AtqaHLqZA==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -359,9 +359,9 @@
           }
         },
         "map-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-          "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
+          "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ=="
         },
         "qs": {
           "version": "6.5.2",
@@ -9030,9 +9030,9 @@
       },
       "dependencies": {
         "map-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-          "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
+          "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.22",
+    "@companieshouse/api-sdk-node": "^1.0.23",
     "@companieshouse/structured-logging-node": "1.0.4",
     "body-parser": "^1.19.0",
     "cookies": "^0.8.0",

--- a/src/client/apiclient.ts
+++ b/src/client/apiclient.ts
@@ -21,10 +21,10 @@ export const getCompanies =
     };
 
 export const getDissolvedCompanies =
-async (apiKey: string, companyName: string, requestId): Promise<DissolvedCompaniesResource> => {
+async (apiKey: string, companyName: string, requestId, searchType: string): Promise<DissolvedCompaniesResource> => {
     const api = createApiClient(apiKey, undefined, API_URL);
     const companiesResource: Resource<DissolvedCompaniesResource> =
-        await api.dissolvedSearch.getCompanies(companyName, requestId);
+        await api.dissolvedSearch.getCompanies(companyName, requestId, searchType);
     if (companiesResource.httpStatusCode !== 200 && companiesResource.httpStatusCode !== 201) {
         throw createError(companiesResource.httpStatusCode, companiesResource.httpStatusCode.toString());
     }

--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -34,9 +34,9 @@ const route = async (req: Request, res: Response) => {
 
         try {
             if (searchTypeRequestParam === "alphabetical") {
-                searchType = "alphabetical"
+                searchType = "alphabetical";
             } else {
-                searchType = "bestMatch"
+                searchType = "bestMatch";
             };
 
             const companyResource: CompaniesResource =

--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -23,16 +23,24 @@ const route = async (req: Request, res: Response) => {
 
     if (errors.isEmpty()) {
         const companyNameRequestParam: string = req.query.companyName as string;
+        const searchTypeRequestParam: string = req.query.searchType as string;
         const companyName: string = companyNameRequestParam;
         const encodedCompanyName: string = encodeURIComponent(companyName);
         Date();
         const lastUpdatedMessage: string = LAST_UPDATED_MESSAGE;
 
         let searchResults;
+        let searchType: string;
 
         try {
+            if (searchTypeRequestParam === "alphabetical") {
+                searchType = "alphabetical"
+            } else {
+                searchType = "bestMatch"
+            };
+
             const companyResource: CompaniesResource =
-                await getDissolvedCompanies(API_KEY, encodedCompanyName, cookies.get(SEARCH_WEB_COOKIE_NAME));
+                await getDissolvedCompanies(API_KEY, encodedCompanyName, cookies.get(SEARCH_WEB_COOKIE_NAME), searchType);
 
             const topHit = companyResource.top_hit;
             let noNearestMatch: boolean = true;

--- a/src/test/client/apiclient.spec.unit.ts
+++ b/src/test/client/apiclient.spec.unit.ts
@@ -76,7 +76,7 @@ const mockDissolvedResponse: Resource<DissolvedCompanyResource> = {
             ]
         }
     }
-}
+};
 
 const mockRequestID: string = "ID";
 

--- a/src/test/client/apiclient.spec.unit.ts
+++ b/src/test/client/apiclient.spec.unit.ts
@@ -2,8 +2,10 @@ import sinon from "sinon";
 import chai from "chai";
 import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
 import { CompaniesResource } from "@companieshouse/api-sdk-node/dist/services/search/alphabetical-search/types";
-import { getCompanies } from "../../client/apiclient";
+import { CompaniesResource as DissolvedCompanyResource } from "@companieshouse/api-sdk-node/dist/services/search/dissolved-search/types";
+import { getCompanies, getDissolvedCompanies } from "../../client/apiclient";
 import AlphabeticalSearchService from "@companieshouse/api-sdk-node/dist/services/search/alphabetical-search/service";
+import DissolvedSearchService from "@companieshouse/api-sdk-node/dist/services/search/dissolved-search/service";
 
 const mockResponse: Resource<CompaniesResource> = {
     httpStatusCode: 200,
@@ -28,6 +30,54 @@ const mockResponse: Resource<CompaniesResource> = {
     }
 };
 
+const mockDissolvedResponse: Resource<DissolvedCompanyResource> = {
+    httpStatusCode: 200,
+    resource: {
+        etag: "etag",
+        items: [
+            {
+                address: {
+                    locality: "cardiff",
+                    postal_code: "cf5 6rb"
+                },
+                company_name: "test company",
+                company_number: "0000789",
+                company_status: "active",
+                date_of_cessation: (new Date("19910212")),
+                date_of_creation: (new Date("19910212")),
+                kind: "kind",
+                previous_company_names: [
+                    {
+                        ceased_on: (new Date("19910212")),
+                        effective_from: (new Date("19910212")),
+                        name: "old name"
+                    }
+                ]
+            }
+        ],
+        kind: "kind",
+        top_hit: {
+            address: {
+                locality: "cardiff",
+                postal_code: "cf5 6rb"
+            },
+            company_name: "test company",
+            company_number: "0000789",
+            company_status: "active",
+            date_of_cessation: (new Date("19910212")),
+            date_of_creation: (new Date("19910212")),
+            kind: "kind",
+            previous_company_names: [
+                {
+                    ceased_on: (new Date("19910212")),
+                    effective_from: (new Date("19910212")),
+                    name: "old name"
+                }
+            ]
+        }
+    }
+}
+
 const mockRequestID: string = "ID";
 
 const sandbox = sinon.createSandbox();
@@ -45,6 +95,24 @@ describe("api.client", () => {
 
             const alphabeticalSearchResults = await getCompanies("api key", "TEST COMPANY NAME", mockRequestID);
             chai.expect(alphabeticalSearchResults).to.equal(mockResponse.resource);
+        });
+    });
+
+    describe("dissolved search", () => {
+        it("GET returns alphabetical search results", async () => {
+            sandbox.stub(DissolvedSearchService.prototype, "getCompanies")
+                .returns(Promise.resolve(mockDissolvedResponse));
+
+            const dissolvedAlphabeticalSearchResults = await getDissolvedCompanies("api key", "test company", mockRequestID, "alphabetical");
+            chai.expect(dissolvedAlphabeticalSearchResults).to.equal(mockDissolvedResponse.resource);
+        });
+
+        it("GET returns best match search results, this is the default search option for dissolved", async () => {
+            sandbox.stub(DissolvedSearchService.prototype, "getCompanies")
+                .returns(Promise.resolve(mockDissolvedResponse));
+
+            const dissolvedAlphabeticalSearchResults = await getDissolvedCompanies("api key", "test company", mockRequestID, "");
+            chai.expect(dissolvedAlphabeticalSearchResults).to.equal(mockDissolvedResponse.resource);
         });
     });
 });

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -262,4 +262,21 @@ describe("search.controller.spec.unit", () => {
             chai.expect(resp.status).to.equal(200);
         });
     });
+
+    describe("check it displays alphabetical search results when checkbox for alphabetical is ticked", () => {
+        it("should return a results page successfully", async () => {
+            getCompanyItemStub = sandbox.stub(apiClient, "getDissolvedCompanies")
+            .returns(Promise.resolve(mockResponseBody));
+
+            const resp = await chai.request(testApp)
+                .get("/dissolved-search/get-results")
+                .type("form")
+                .send({
+                  "companyName": "company",
+                  'searchType': 'alphabetical',
+                })
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("0000789");
+        });
+    });
 });

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -266,15 +266,15 @@ describe("search.controller.spec.unit", () => {
     describe("check it displays alphabetical search results when checkbox for alphabetical is ticked", () => {
         it("should return a results page successfully", async () => {
             getCompanyItemStub = sandbox.stub(apiClient, "getDissolvedCompanies")
-            .returns(Promise.resolve(mockResponseBody));
+                .returns(Promise.resolve(mockResponseBody));
 
             const resp = await chai.request(testApp)
                 .get("/dissolved-search/get-results")
                 .type("form")
                 .send({
-                  "companyName": "company",
-                  'searchType': 'alphabetical',
-                })
+                    companyName: "company",
+                    searchType: "alphabetical"
+                });
             chai.expect(resp.status).to.equal(200);
             chai.expect(resp.text).to.contain("0000789");
         });

--- a/src/views/dissolved-search/index.html
+++ b/src/views/dissolved-search/index.html
@@ -31,6 +31,7 @@
       },
         items: [
             {
+            name: "searchType",
             value: "alphabetical",
             text: "Show results alphabetically",
             attributes: {

--- a/src/views/dissolved-search/index.html
+++ b/src/views/dissolved-search/index.html
@@ -30,7 +30,7 @@
         }
       },
         items: [
-            {
+          {
             name: "searchType",
             value: "alphabetical",
             text: "Show results alphabetically",


### PR DESCRIPTION
When a user selects the alphabetical search tick box within dissolved search it adds a query param of searchType=alphabetical. This value is used within the apiClient call to get a list of alphabetically searched dissolved companies.

Resolves: BI-7347