### PR TITLE
add js on page load to remove alphabetical search checkbox checked

### DIFF
--- a/src/views/dissolved-search/index.html
+++ b/src/views/dissolved-search/index.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
+<script>onLoad()</script>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl">

--- a/static/js/matcher.js
+++ b/static/js/matcher.js
@@ -14,3 +14,9 @@ function changeThis(sender) {
         document.getElementById("which-company-name-to-search-2").removeAttribute('disabled');
     }
 };
+
+function onLoad() {
+    window.addEventListener('load', function() {
+        document.getElementById("alphabetical").checked = false;
+    })
+};


### PR DESCRIPTION
On page refresh after using browser back button it will remove alphabetical search checkbox being checked if previously checked. Without this a user could select both alphabetical and previous company names with JS on.

Resolves: BI-7651