### PR TITLE
Bi 7009 add paging to alpha search

### DIFF
--- a/src/controllers/alphabetical-search/search.controller.ts
+++ b/src/controllers/alphabetical-search/search.controller.ts
@@ -39,23 +39,24 @@ const route = async (req: Request, res: Response) => {
             let noNearestMatch: boolean = true;
             const lastIndexPosition = companyResource.results.length -1;
 
-            const interimPreviousPageName = encodeURIComponent(companyResource.results[0].items.corporate_name);
-            const interimNextPageName = encodeURIComponent(companyResource.results[lastIndexPosition].items.corporate_name);
+            // const interimPreviousPageName = encodeURIComponent(companyResource.results[0]?.items.corporate_name);
+            // const interimNextPageName = encodeURIComponent(companyResource.results[lastIndexPosition]?.items.corporate_name);
             
-            const interimPrevCompanyResource: CompaniesResource = 
-                await getCompanies(API_KEY, interimPreviousPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
+            // const interimPrevCompanyResource: CompaniesResource = 
+            //     await getCompanies(API_KEY, interimPreviousPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
 
-            const interimNextCompanyResource: CompaniesResource =
-                await getCompanies(API_KEY, interimNextPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
+            // const interimNextCompanyResource: CompaniesResource =
+            //     await getCompanies(API_KEY, interimNextPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
 
-            previousUrl = "get-results?companyName=" + interimPrevCompanyResource.results[0].items.corporate_name.replace(/\s/g, '+');
-            nextUrl = "get-results?companyName=" + interimNextCompanyResource.results[lastIndexPosition].items.corporate_name.replace(/\s/g, '+');
+            previousUrl = "get-results?companyName=" + companyResource.results[0]?.items.corporate_name.replace(/\s/g, '+');
+            nextUrl = "get-results?companyName=" + companyResource.results[lastIndexPosition]?.items.corporate_name.replace(/\s/g, '+');
 
             showPrevLink =  req.url.includes(previousUrl) ? false: true;
             showNextLink = req.url.includes(nextUrl) ? false : true;
             
-            searchResults = companyResource.results.map((result) => {
-                const status = result.items.company_status;
+            const slicedCompanyResource = companyResource.results.slice(20, 61);
+            searchResults = slicedCompanyResource.map((result) => {
+                const status = result?.items.company_status;
                 let capitalisedStatus: string = "";
                 let nearestClass: string = "";
 
@@ -68,7 +69,7 @@ const route = async (req: Request, res: Response) => {
                     noNearestMatch = false;
                 }
 
-                const sanitisedCorporateName = escape(result.items.corporate_name);
+                const sanitisedCorporateName = escape(result?.items.corporate_name);
 
                 return [
                     {
@@ -76,7 +77,7 @@ const route = async (req: Request, res: Response) => {
                         html: `<a href="${result.links.self}">${sanitisedCorporateName}</a>`
                     },
                     {
-                        text: result.items.company_number
+                        text: result?.items.company_number
                     },
                     {
                         text: capitalisedStatus

--- a/src/controllers/alphabetical-search/search.controller.ts
+++ b/src/controllers/alphabetical-search/search.controller.ts
@@ -36,25 +36,16 @@ const route = async (req: Request, res: Response) => {
                 await getCompanies(API_KEY, encodedCompanyName, cookies.get(SEARCH_WEB_COOKIE_NAME));
 
             const topHit: string = companyResource.topHit;
-            let noNearestMatch: boolean = true;
-            const lastIndexPosition = companyResource.results.length -1;
-
-            // const interimPreviousPageName = encodeURIComponent(companyResource.results[0]?.items.corporate_name);
-            // const interimNextPageName = encodeURIComponent(companyResource.results[lastIndexPosition]?.items.corporate_name);
-            
-            // const interimPrevCompanyResource: CompaniesResource = 
-            //     await getCompanies(API_KEY, interimPreviousPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
-
-            // const interimNextCompanyResource: CompaniesResource =
-            //     await getCompanies(API_KEY, interimNextPageName, cookies.get(SEARCH_WEB_COOKIE_NAME));
-
-            previousUrl = "get-results?companyName=" + companyResource.results[0]?.items.corporate_name.replace(/\s/g, '+');
-            nextUrl = "get-results?companyName=" + companyResource.results[lastIndexPosition]?.items.corporate_name.replace(/\s/g, '+');
-
-            showPrevLink =  req.url.includes(previousUrl) ? false: true;
-            showNextLink = req.url.includes(nextUrl) ? false : true;
-            
+            const lastIndexPosition = companyResource.results.length - 1;
             const slicedCompanyResource = companyResource.results.slice(20, 61);
+            let noNearestMatch: boolean = true;
+
+            previousUrl = "get-results?companyName=" + companyResource.results[0]?.items.corporate_name.replace(/\s/g, "+");
+            nextUrl = "get-results?companyName=" + companyResource.results[lastIndexPosition]?.items.corporate_name.replace(/\s/g, "+");
+
+            showPrevLink = !req.url.includes(previousUrl);
+            showNextLink = !req.url.includes(nextUrl);
+
             searchResults = slicedCompanyResource.map((result) => {
                 const status = result?.items.company_status;
                 let capitalisedStatus: string = "";

--- a/src/controllers/alphabetical-search/search.controller.ts
+++ b/src/controllers/alphabetical-search/search.controller.ts
@@ -30,6 +30,7 @@ const route = async (req: Request, res: Response) => {
         let nextUrl;
         let showPrevLink;
         let showNextLink;
+        let slicedCompanyResource;
 
         try {
             const companyResource: CompaniesResource =
@@ -37,8 +38,11 @@ const route = async (req: Request, res: Response) => {
 
             const topHit: string = companyResource.topHit;
             const lastIndexPosition = companyResource.results.length - 1;
-            const slicedCompanyResource = companyResource.results.slice(20, 61);
             let noNearestMatch: boolean = true;
+
+            if (companyResource.results.length > 20) {
+                slicedCompanyResource = companyResource.results.slice(20, 61);
+            };
 
             previousUrl = "get-results?companyName=" + companyResource.results[0]?.items.corporate_name.replace(/\s/g, "+");
             nextUrl = "get-results?companyName=" + companyResource.results[lastIndexPosition]?.items.corporate_name.replace(/\s/g, "+");

--- a/src/test/MockUtils/alphabetical-search/mock.utils.ts
+++ b/src/test/MockUtils/alphabetical-search/mock.utils.ts
@@ -1,6 +1,6 @@
 import { CompaniesResource, Result, Items, Links } from "@companieshouse/api-sdk-node/dist/services/search/alphabetical-search/types";
 
-export const getDummyCompanyResource = (name?: string): CompaniesResource => {
+export const getDummyCompanyResource = (name: string): CompaniesResource => {
     return {
         searchType: "searchType",
         topHit: "topHit",
@@ -16,27 +16,27 @@ export const getDummyCompanyResourceEmpty = (): CompaniesResource => {
     };
 };
 
-export const createDummyResults = (name?: string): Result[] => {
-    const results: Result[] = [createDummyResult(name)];
+export const createDummyResults = (name: string): Result[] => {
+    const results: Result[] = createArrayDummyResults(name);
     return results;
 };
 
-export const createDummyResult = (name?: string): Result => {
-    return {
-        ID: "ID",
-        company_type: "company_type",
-        items: createDummyItems(name),
-        links: createDummyLinks()
-    };
-};
-
-export const createDummyItems = (name = "Test"): Items => {
-    return {
-        company_number: "00006400",
-        company_status: "active",
-        corporate_name: name,
-        record_type: "test"
-    };
+export const createArrayDummyResults = (name: string) : Result[] => {
+    const resultsArray: Result[] = [];
+    for (let i = 0; i < 81; i++) {
+        resultsArray.push({
+            ID: "id",
+            company_type: "company_type",
+            items: {
+                company_number: "00006400",
+                company_status: "active",
+                corporate_name: name + i,
+                record_type: "test"
+            },
+            links: createDummyLinks()
+        });
+    }
+    return resultsArray;
 };
 
 export const createDummyLinks = (): Links => {

--- a/src/test/controllers/alphabetical-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/alphabetical-search/search.controller.spec.unit.ts
@@ -1,6 +1,7 @@
 import * as mockUtils from "../../MockUtils/alphabetical-search/mock.utils";
 import sinon from "sinon";
 import chai from "chai";
+import cheerio from "cheerio";
 import * as apiClient from "../../../client/apiclient";
 
 const sandbox = sinon.createSandbox();
@@ -21,7 +22,7 @@ describe("search.controller.spec.unit", () => {
     describe("check it returns a results page successfully", () => {
         it("should return a results page successfully", async () => {
             getCompanyItemStub = sandbox.stub(apiClient, "getCompanies")
-                .returns(Promise.resolve(mockUtils.getDummyCompanyResource()));
+                .returns(Promise.resolve(mockUtils.getDummyCompanyResource("nab")));
 
             const resp = await chai.request(testApp)
                 .get("/alphabetical-search/get-results?companyName=nab");
@@ -42,6 +43,22 @@ describe("search.controller.spec.unit", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect(resp.text).to.contain("00006400");
             chai.expect(resp.text).to.contain("&lt;I&gt;company_name&lt;/I&gt;");
+        });
+    });
+
+    describe("check previous and next urls have the correct links being created from the results array", () => {
+        it("check previous and next urls have the correct links being created from the results array", async () => {
+            getCompanyItemStub = sandbox.stub(apiClient, "getCompanies")
+                .returns(Promise.resolve(mockUtils.getDummyCompanyResource("nab")));
+
+            const resp = await chai.request(testApp)
+                .get("/alphabetical-search/get-results?companyName=nab");
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($("#previousLink").attr("href")).to.include("nab0");
+            chai.expect($("#nextLink").attr("href")).to.include("nab80");
         });
     });
 

--- a/src/views/alphabetical-search/results.html
+++ b/src/views/alphabetical-search/results.html
@@ -34,10 +34,10 @@
       }) }}
       <div class="pagination">
         {% if showPrevLink %}
-            <a class="govuk-link" href={{previousUrl}}>Previous</a>
+            <a class="govuk-link" id="previousLink" href={{previousUrl}}>Previous</a>
         {% endif %}
         {% if showNextLink %}
-            <a class="govuk-link" href={{nextUrl}}>Next</a>
+            <a class="govuk-link" id="nextLink" href={{nextUrl}}>Next</a>
         {% endif %}
       </div>
     {% else %}

--- a/src/views/alphabetical-search/results.html
+++ b/src/views/alphabetical-search/results.html
@@ -32,6 +32,14 @@
           ],
           rows: searchResults
       }) }}
+      <div class="pagination">
+        {% if showPrevLink %}
+            <a class="govuk-link" href={{previousUrl}}>Previous</a>
+        {% endif %}
+        {% if showNextLink %}
+            <a class="govuk-link" href={{nextUrl}}>Next</a>
+        {% endif %}
+      </div>
     {% else %}
       <h2 class="govuk-heading-l" style="overflow-wrap: break-word;">No results found for "{{ searchTerm }}"</h2>
       <p class="govuk-body">Please try searching again using a different search criteria.</p>

--- a/static/alphabetical_search.scss
+++ b/static/alphabetical_search.scss
@@ -97,3 +97,13 @@ html, body {
     padding-left: 0.5em;
   }
 }
+
+.pagination {
+  display: inline-block;
+  }
+  
+.pagination a {
+  float: left;
+  font-size: 19px;
+  padding: 8px 30px 0px 0px;
+  }


### PR DESCRIPTION
Added previous and next links, this takes the first and last company names from the returned array and concat them as the hrefs.
Implementation to not display the next or previous links when the user is at the start or end of the alphabetical search results.

Resolves: BI-7009 & BI-7008