### PR TITLE
add query param to persist original search top hit company number

### DIFF
--- a/src/test/MockUtils/alphabetical-search/mock.utils.ts
+++ b/src/test/MockUtils/alphabetical-search/mock.utils.ts
@@ -3,7 +3,7 @@ import { CompaniesResource, Result, Items, Links } from "@companieshouse/api-sdk
 export const getDummyCompanyResource = (name: string): CompaniesResource => {
     return {
         searchType: "searchType",
-        topHit: "topHit",
+        topHit: "companyNameTest41",
         results: createDummyResults(name)
     };
 };
@@ -23,12 +23,12 @@ export const createDummyResults = (name: string): Result[] => {
 
 export const createArrayDummyResults = (name: string) : Result[] => {
     const resultsArray: Result[] = [];
-    for (let i = 0; i < 81; i++) {
+    for (let i = 0; i < 82; i++) {
         resultsArray.push({
             ID: "id",
             company_type: "company_type",
             items: {
-                company_number: "00006400",
+                company_number: "00006400" + i,
                 company_status: "active",
                 corporate_name: name + i,
                 record_type: "test"

--- a/src/test/controllers/alphabetical-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/alphabetical-search/search.controller.spec.unit.ts
@@ -58,7 +58,31 @@ describe("search.controller.spec.unit", () => {
 
             chai.expect(resp.status).to.equal(200);
             chai.expect($("#previousLink").attr("href")).to.include("nab0");
-            chai.expect($("#nextLink").attr("href")).to.include("nab80");
+            chai.expect($("#nextLink").attr("href")).to.include("nab81");
+        });
+    });
+
+    describe("check that the searched term result is only highlighted using pagination", () => {
+        it("check the search term is highlighted", async () => {
+            getCompanyItemStub = sandbox.stub(apiClient, "getCompanies")
+                .returns(Promise.resolve(mockUtils.getDummyCompanyResource("companyNameTest")));
+
+            const resp = await chai.request(testApp)
+                .get("/alphabetical-search/get-results?companyName=companyNameTest&originalCompanyNumber=0000640041");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("nearest");
+        });
+
+        it("check the no result is highlighted on screen", async () => {
+            getCompanyItemStub = sandbox.stub(apiClient, "getCompanies")
+                .returns(Promise.resolve(mockUtils.getDummyCompanyResource("companyNameTest")));
+
+            const resp = await chai.request(testApp)
+                .get("/alphabetical-search/get-results?companyName=companyNameTest&originalCompanyNumber=0000540041");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.not.contain("nearest");
         });
     });
 


### PR DESCRIPTION
add query param to persist original search top hit company number
add logic to highlight only the top hit search when paging through results
add test to cover the highlighted company