### PR TITLE
Refresh index page when no search term input by user

### DIFF
--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -43,6 +43,10 @@ const route = async (req: Request, res: Response) => {
         let searchType: string;
 
         try {
+            if (companyNameRequestParam === "") {
+                return res.render(templatePaths.DISSOLVED_INDEX);
+            }
+
             if (searchTypeRequestParam === ALPHABETICAL_SEARCH_TYPE) {
                 searchType = ALPHABETICAL_SEARCH_TYPE;
             } else if (changeNameTypeParam === PREVIOUS_NAME_SEARCH_TYPE) {

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -256,6 +256,32 @@ describe("search.controller.spec.unit", () => {
         });
     });
 
+    describe("check the index page refreshes if no search is entered", () => {
+        it("should refresh when no input and company name when it was dissolved is selected", async () => {
+            const resp = await chai.request(testApp)
+                .get("/dissolved-search/get-results?companyName=&changedName=name-at-dissolution");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("Search for a dissolved company");
+        });
+
+        it("should refresh when no input and previous company names is selected", async () => {
+            const resp = await chai.request(testApp)
+                .get("/dissolved-search/get-results?companyName=&changedName=previousNameDissolved");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("Search for a dissolved company");
+        });
+
+        it("should refresh when no input and company name when it was dissolved and show results alphabetically are selected ", async () => {
+            const resp = await chai.request(testApp)
+                .get("/dissolved-search/get-results?companyName=&searchType=alphabetical&changedName=name-at-dissolution");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("Search for a dissolved company");
+        });
+    });
+
     describe("check it displays an error message if a company name hasn't been entered", () => {
         it("should display an error message if no company name is entered", async () => {
             const resp = await chai.request(testApp)


### PR DESCRIPTION
The index page will refresh rather than show a no results screen when a user does not input a search term when:
Company name when it was dissolved is selected
or 
Previous company names is selected
or 
Show results alphabetically and Company name when it was dissolved is selected

Resolves: BI-7899