### PR TITLE
Bi 7009 add pagination to alpha search

### DIFF
--- a/src/controllers/alphabetical-search/search.controller.ts
+++ b/src/controllers/alphabetical-search/search.controller.ts
@@ -40,8 +40,11 @@ const route = async (req: Request, res: Response) => {
             const lastIndexPosition = companyResource.results.length - 1;
             let noNearestMatch: boolean = true;
             let originalCompanyNumber;
+            let indexTopHitMatchCorpName = companyResource.results.findIndex(x => x.items.corporate_name === topHit);
 
-            if (companyResource.results.length > 20) {
+            if (companyResource.results[0].items.corporate_name === topHit || indexTopHitMatchCorpName < 20) {
+                slicedCompanyResource = companyResource.results.slice(0, 41);
+            } else if (companyResource.results.length > 20) {
                 slicedCompanyResource = companyResource.results.slice(20, 61);
             }
 
@@ -49,12 +52,15 @@ const route = async (req: Request, res: Response) => {
                 const status = result?.items.company_status;
                 let capitalisedStatus: string = "";
                 let nearestClass: string = "";
+                // console.log(result.items.corporate_name)
 
                 if (status !== undefined) {
                     capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1);
                 }
 
                 if (result.items.corporate_name === topHit && noNearestMatch) {
+                    console.log("companynumber",result.items.company_number);
+                    console.log("originalnumber",originalCompanyNumber);
                     if (!req.query.originalCompanyNumber) {
                         originalCompanyNumber = result?.items.company_number;
                     } else {
@@ -64,6 +70,7 @@ const route = async (req: Request, res: Response) => {
                         nearestClass = "nearest";
                         noNearestMatch = false;
                     }
+                    console.log("originalnumber",originalCompanyNumber);
                 }
 
                 const sanitisedCorporateName = escape(result?.items.corporate_name);

--- a/src/controllers/alphabetical-search/search.controller.ts
+++ b/src/controllers/alphabetical-search/search.controller.ts
@@ -5,6 +5,7 @@ import { CompaniesResource } from "@companieshouse/api-sdk-node/dist/services/se
 import { createLogger } from "@companieshouse/structured-logging-node";
 import { SEARCH_WEB_COOKIE_NAME, API_KEY, APPLICATION_NAME } from "../../config/config";
 import { getCompanies } from "../../client/apiclient";
+import { getDisplayList } from "../utils";
 import * as templatePaths from "../../model/template.paths";
 import * as errorMessages from "../../model/error.messages";
 
@@ -40,27 +41,19 @@ const route = async (req: Request, res: Response) => {
             const lastIndexPosition = companyResource.results.length - 1;
             let noNearestMatch: boolean = true;
             let originalCompanyNumber;
-            let indexTopHitMatchCorpName = companyResource.results.findIndex(x => x.items.corporate_name === topHit);
 
-            if (companyResource.results[0].items.corporate_name === topHit || indexTopHitMatchCorpName < 20) {
-                slicedCompanyResource = companyResource.results.slice(0, 41);
-            } else if (companyResource.results.length > 20) {
-                slicedCompanyResource = companyResource.results.slice(20, 61);
-            }
+            slicedCompanyResource = getDisplayList(companyResource.results, topHit);
 
             searchResults = slicedCompanyResource.map((result) => {
                 const status = result?.items.company_status;
                 let capitalisedStatus: string = "";
                 let nearestClass: string = "";
-                // console.log(result.items.corporate_name)
 
                 if (status !== undefined) {
                     capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1);
                 }
 
                 if (result.items.corporate_name === topHit && noNearestMatch) {
-                    console.log("companynumber",result.items.company_number);
-                    console.log("originalnumber",originalCompanyNumber);
                     if (!req.query.originalCompanyNumber) {
                         originalCompanyNumber = result?.items.company_number;
                     } else {
@@ -70,7 +63,6 @@ const route = async (req: Request, res: Response) => {
                         nearestClass = "nearest";
                         noNearestMatch = false;
                     }
-                    console.log("originalnumber",originalCompanyNumber);
                 }
 
                 const sanitisedCorporateName = escape(result?.items.corporate_name);

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -71,3 +71,19 @@ export const formatDate = (unformattedDate) => {
 
     return dateToReturn;
 };
+
+export const getDisplayList = (list, topHit) => {
+    const counter = list.findIndex((name) => { return name.items.corporate_name === topHit });
+    const before = 20;
+    const after = 20;
+    let start;
+    let finish;
+    if ((counter - before) > 0) {
+        start = counter - before;
+        finish = 1 + counter + after;
+    } else {
+        start = 0;
+        finish = 1 + counter + after;
+    }
+    return list.slice(start, finish);
+};

--- a/src/test/MockUtils/alphabetical-search/mock.utils.ts
+++ b/src/test/MockUtils/alphabetical-search/mock.utils.ts
@@ -1,9 +1,9 @@
 import { CompaniesResource, Result, Items, Links } from "@companieshouse/api-sdk-node/dist/services/search/alphabetical-search/types";
 
-export const getDummyCompanyResource = (name: string): CompaniesResource => {
+export const getDummyCompanyResource = (name: string, topHit: string): CompaniesResource => {
     return {
         searchType: "searchType",
-        topHit: "companyNameTest41",
+        topHit: topHit,
         results: createDummyResults(name)
     };
 };


### PR DESCRIPTION
Added functionality to highlight the top hit company and to always return either the following or previous 20 companies if the top hit result is at the start or end of the index.

Resolves BI-7009