### PR TITLE
Add paging improvements to alpha search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -338,9 +338,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.27.tgz",
-      "integrity": "sha512-cUl2JA1/ugdjrblaxiShYPAVW8AfuN1rQnnj3j1mUspEZb940xK6V6qOxhKGeIM6JFdfacg/ZzX0X3Vs2lW1DA==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.28.tgz",
+      "integrity": "sha512-RakonnXYAzWxEH9YoP0XXsvjZN1OkCnYDxSoei1YjEstdzFqTxaRc9/XWY9hLEJ9G3DT2C4psn6cWpcCuCr+6Q==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.27",
+    "@companieshouse/api-sdk-node": "^1.0.28",
     "@companieshouse/structured-logging-node": "1.0.4",
     "body-parser": "^1.19.0",
     "cookies": "^0.8.0",

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -87,3 +87,16 @@ export const getDisplayList = (list, topHit) => {
     }
     return list.slice(start, finish);
 };
+
+export const showPrevNextLinks = (list, topHit) => {
+    const indexPosition = list.findIndex((name) => { return name.items.corporate_name === topHit });
+    let showPrevLink = true;
+    let showNextLink = true;
+    if (indexPosition < 20) {
+        showPrevLink = false;
+    }
+    if (indexPosition > list.length - 20) {
+        showNextLink = false;
+    }
+    return [showPrevLink, showNextLink];
+};

--- a/src/test/MockUtils/alphabetical-search/mock.utils.ts
+++ b/src/test/MockUtils/alphabetical-search/mock.utils.ts
@@ -1,10 +1,10 @@
 import { CompaniesResource, Result, Items, Links } from "@companieshouse/api-sdk-node/dist/services/search/alphabetical-search/types";
 
-export const getDummyCompanyResource = (name: string, topHit: string): CompaniesResource => {
+export const getDummyCompanyResource = (name: string, topHit: string, alphaKey: string): CompaniesResource => {
     return {
         searchType: "searchType",
         topHit: topHit,
-        results: createDummyResults(name)
+        results: createDummyResults(name, alphaKey)
     };
 };
 
@@ -16,12 +16,12 @@ export const getDummyCompanyResourceEmpty = (): CompaniesResource => {
     };
 };
 
-export const createDummyResults = (name: string): Result[] => {
-    const results: Result[] = createArrayDummyResults(name);
+export const createDummyResults = (name: string, alphaKey: string): Result[] => {
+    const results: Result[] = createArrayDummyResults(name, alphaKey);
     return results;
 };
 
-export const createArrayDummyResults = (name: string) : Result[] => {
+export const createArrayDummyResults = (name: string, alphaKey: string) : Result[] => {
     const resultsArray: Result[] = [];
     for (let i = 0; i < 82; i++) {
         resultsArray.push({
@@ -32,7 +32,7 @@ export const createArrayDummyResults = (name: string) : Result[] => {
                 company_status: "active",
                 corporate_name: name + i,
                 record_type: "test",
-                ordered_alpha_key: name + i
+                ordered_alpha_key: alphaKey
             },
             links: createDummyLinks()
         });


### PR DESCRIPTION
Added functionality to display prev or next links if on first or last page of search. Some companies do not have an alpha key to create the prev or next links, these will now use an encoded company name.
Added tests to cover this new functionality.

Resolves: BI-7009 & BI-7708