### PR TITLE
Amended to add encoding to the company name for the paging link url

### DIFF
--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -64,7 +64,7 @@ const route = async (req: Request, res: Response) => {
 
         const numberOfPages: number = Math.ceil(companyResource.hits / DISSOLVED_SEARCH_NUMBER_OF_RESULTS);
 
-        const partialHref: string = "get-results?companyName=" + companyNameRequestParam + "&changedName=" + changeNameTypeParam;
+        const partialHref: string = "get-results?companyName=" + encodeURIComponent(companyNameRequestParam) + "&changedName=" + changeNameTypeParam;
 
         const searchBeforeAlphaKey = items[0]?.ordered_alpha_key_with_id;
         const searchAfterAlphaKey = items[items.length - 1]?.ordered_alpha_key_with_id;


### PR DESCRIPTION
Amended to add encoding to the company name for the paging link url

Resolves issues around paging previous company name results where the company name to search for includes an &