### PR TITLE
BI-8266 display RO address

### DIFF
--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -6,7 +6,7 @@ import { createLogger } from "@companieshouse/structured-logging-node";
 import { getDissolvedCompanies } from "../../client/apiclient";
 
 import { SEARCH_WEB_COOKIE_NAME, API_KEY, APPLICATION_NAME, LAST_UPDATED_MESSAGE, DISSOLVED_SEARCH_NUMBER_OF_RESULTS } from "../../config/config";
-import { detectNearestMatch, formatDate, formatPostCode, generateSize, sanitiseCompanyName } from "../utils";
+import { detectNearestMatch, formatDate, generateSize, sanitiseCompanyName, generateROAddress } from "../utils";
 import * as templatePaths from "../../model/template.paths";
 import * as errorMessages from "../../model/error.messages";
 import Cookies = require("cookies");
@@ -182,7 +182,7 @@ const previousNameResults = (company_name, company_number, date_of_cessation, da
             classes: "govuk-table__cell no-wrap"
         },
         {
-            text: formatPostCode(registered_office_address?.postal_code)
+            text: generateROAddress(registered_office_address)
         }
     ];
 };
@@ -204,7 +204,7 @@ const alphabeticalMapping = (nearestClass, company_name, company_number, date_of
             classes: "govuk-table__cell no-wrap"
         },
         {
-            text: formatPostCode(registered_office_address?.postal_code)
+            text: generateROAddress(registered_office_address)
         }
     ];
 };
@@ -225,7 +225,7 @@ const bestMatchMapping = (company_name, company_number, date_of_cessation, date_
             classes: "govuk-table__cell no-wrap"
         },
         {
-            text: formatPostCode(registered_office_address?.postal_code)
+            text: generateROAddress(registered_office_address)
         }
     ];
 };

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -5,33 +5,29 @@ export const sanitiseCompanyName = (companyName) => {
 };
 
 export const generateROAddress = (registered_office_address) => {
-    
     let addressLine1 = "";
     let addressLine2 = "";
     let town = "";
     let postCode = "";
-    let fullAddressToBeDisplayed
 
-    if (registered_office_address?.address_line_1 != null || registered_office_address?.address_line_1 != undefined) {
-        addressLine1 = registered_office_address.address_line_1 + ", ";
+    if (registered_office_address?.address_line_1 != undefined) {
+        addressLine1 = registered_office_address?.address_line_1 + ", ";
     }
 
-    if (registered_office_address?.address_line_2 != null || registered_office_address?.address_line_2 != undefined) {
-        addressLine2 = registered_office_address.address_line_2 + ", ";
+    if (registered_office_address?.address_line_2 != undefined) {
+        addressLine2 = registered_office_address?.address_line_2 + ", ";
     }
 
-    if (registered_office_address?.locality != null || registered_office_address?.locality != undefined) {
-        town = registered_office_address.locality + ", ";
+    if (registered_office_address?.locality != undefined) {
+        town = registered_office_address?.locality + ", ";
     }
 
-    if (registered_office_address?.postal_code != null || registered_office_address?.postal_code != undefined) {
-        town = registered_office_address.postal_code;
+    if (registered_office_address?.postal_code != undefined) {
+        postCode = registered_office_address?.postal_code;
     }
 
-    fullAddressToBeDisplayed = addressLine1 + addressLine2 + town + postCode;
-
-    return fullAddressToBeDisplayed;
-}
+    return addressLine1 + addressLine2 + town + postCode;
+};
 
 export const formatDate = (unformattedDate) => {
     if (unformattedDate === undefined) {

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -10,19 +10,19 @@ export const generateROAddress = (registered_office_address) => {
     let town = "";
     let postCode = "";
 
-    if (registered_office_address?.address_line_1 != undefined) {
-        addressLine1 = registered_office_address?.address_line_1 + ", ";
+    if (registered_office_address?.address_line_1 !== undefined) {
+        addressLine1 = registered_office_address?.address_line_1 + " ";
     }
 
-    if (registered_office_address?.address_line_2 != undefined) {
-        addressLine2 = registered_office_address?.address_line_2 + ", ";
+    if (registered_office_address?.address_line_2 !== undefined) {
+        addressLine2 = registered_office_address?.address_line_2 + " ";
     }
 
-    if (registered_office_address?.locality != undefined) {
-        town = registered_office_address?.locality + ", ";
+    if (registered_office_address?.locality !== undefined) {
+        town = registered_office_address?.locality + " ";
     }
 
-    if (registered_office_address?.postal_code != undefined) {
+    if (registered_office_address?.postal_code !== undefined) {
         postCode = registered_office_address?.postal_code;
     }
 

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -4,19 +4,34 @@ export const sanitiseCompanyName = (companyName) => {
     return escape(companyName);
 };
 
-export const formatPostCode = (postCode) => {
-    let halfPostCode;
-    let trimmedPostCode;
+export const generateROAddress = (registered_office_address) => {
+    
+    let addressLine1 = "";
+    let addressLine2 = "";
+    let town = "";
+    let postCode = "";
+    let fullAddressToBeDisplayed
 
-    if (postCode != null) {
-        const newPostCode = postCode.split(" ");
-        halfPostCode = newPostCode[0];
-
-        trimmedPostCode = halfPostCode.slice(0, 4);
+    if (registered_office_address?.address_line_1 != null || registered_office_address?.address_line_1 != undefined) {
+        addressLine1 = registered_office_address.address_line_1 + ", ";
     }
 
-    return trimmedPostCode;
-};
+    if (registered_office_address?.address_line_2 != null || registered_office_address?.address_line_2 != undefined) {
+        addressLine2 = registered_office_address.address_line_2 + ", ";
+    }
+
+    if (registered_office_address?.locality != null || registered_office_address?.locality != undefined) {
+        town = registered_office_address.locality + ", ";
+    }
+
+    if (registered_office_address?.postal_code != null || registered_office_address?.postal_code != undefined) {
+        town = registered_office_address.postal_code;
+    }
+
+    fullAddressToBeDisplayed = addressLine1 + addressLine2 + town + postCode;
+
+    return fullAddressToBeDisplayed;
+}
 
 export const formatDate = (unformattedDate) => {
     if (unformattedDate === undefined) {

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -1,7 +1,6 @@
 import * as mockUtils from "../../MockUtils/dissolved-search/mock.util";
 import sinon from "sinon";
 import chai from "chai";
-import cheerio from "cheerio";
 import * as apiClient from "../../../client/apiclient";
 import { CompaniesResource } from "@companieshouse/api-sdk-node/dist/services/search/dissolved-search/types";
 import { formatDate, sanitiseCompanyName, generateROAddress } from "../../../controllers/utils";
@@ -121,14 +120,12 @@ describe("search.controller.spec.unit", () => {
 
     describe("check it returns a dissolved results page with an address if available", () => {
         it("should return a results page with the RO address", () => {
-            
             chai.expect(generateROAddress(mockResponseBody.top_hit.registered_office_address)).to.contain("test house");
         });
     });
 
     describe("check it returns a dissolved results page without an address if not available", () => {
         it("should return a results page without the RO address", () => {
-            
             chai.expect(generateROAddress(emptyMockResponseBody.top_hit.registered_office_address)).to.not.contain("test house");
         });
     });

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -4,7 +4,7 @@ import chai from "chai";
 import cheerio from "cheerio";
 import * as apiClient from "../../../client/apiclient";
 import { CompaniesResource } from "@companieshouse/api-sdk-node/dist/services/search/dissolved-search/types";
-import { formatPostCode, formatDate, sanitiseCompanyName } from "../../../controllers/utils";
+import { formatDate, sanitiseCompanyName, generateROAddress } from "../../../controllers/utils";
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
@@ -119,27 +119,17 @@ describe("search.controller.spec.unit", () => {
         });
     });
 
-    describe("check it returns a dissolved results page with a shortened postcode successfully when the postcode has a space", () => {
-        it("should return a results page with a shortened postcode successfully", () => {
-            const postCode: string = "CF5 6RB";
-
-            chai.expect(formatPostCode(postCode)).to.contain("CF5");
+    describe("check it returns a dissolved results page with an address if available", () => {
+        it("should return a results page with the RO address", () => {
+            
+            chai.expect(generateROAddress(mockResponseBody.top_hit.registered_office_address)).to.contain("test house");
         });
     });
 
-    describe("check it returns a dissolved results page with a shortened postcode successfully when the postcode has no space", () => {
-        it("should return a results page with a shortened postcode successfully", () => {
-            const postCode: string = "CF56RB";
-
-            chai.expect(formatPostCode(postCode)).to.contain("CF56");
-        });
-    });
-
-    describe("check it returns a dissolved results page with a shortened postcode successfully when the postcode has a space in an odd place space", () => {
-        it("should return a results page with a shortened postcode successfully", () => {
-            const postCode: string = "CF56R B";
-
-            chai.expect(formatPostCode(postCode)).to.contain("CF56");
+    describe("check it returns a dissolved results page without an address if not available", () => {
+        it("should return a results page without the RO address", () => {
+            
+            chai.expect(generateROAddress(emptyMockResponseBody.top_hit.registered_office_address)).to.not.contain("test house");
         });
     });
 


### PR DESCRIPTION
Checks if an address field has been passed over. Assigns it as nothing if it comes back as undefined so that undefined doesn't show up on the web screen. 
Concatenates address with commas between fields. 

Removed old postcode formatting that is no longer being used

Resolves: BI-8266