### PR TITLE
BI-8462 update text for unavailable RO address

### DIFF
--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -26,6 +26,11 @@ export const generateROAddress = (registered_office_address) => {
         postCode = registered_office_address?.postal_code;
     }
 
+    if (registered_office_address?.address_line_1 === undefined && registered_office_address?.address_line_2 === undefined && 
+        registered_office_address?.locality === undefined && registered_office_address?.postal_code === undefined) {
+        addressLine1 = "Not available";
+    }
+
     return addressLine1 + addressLine2 + town + postCode;
 };
 

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -26,7 +26,7 @@ export const generateROAddress = (registered_office_address) => {
         postCode = registered_office_address?.postal_code;
     }
 
-    if (registered_office_address?.address_line_1 === undefined && registered_office_address?.address_line_2 === undefined && 
+    if (registered_office_address?.address_line_1 === undefined && registered_office_address?.address_line_2 === undefined &&
         registered_office_address?.locality === undefined && registered_office_address?.postal_code === undefined) {
         addressLine1 = "Not available";
     }

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -81,7 +81,7 @@ const emptyMockResponseBody : CompaniesResource = ({
     hits: 20,
     top_hit: {
         registered_office_address: {
-            address_line_1: "Not available",
+            address_line_1: "",
             address_line_2: "",
             locality: "",
             postal_code: ""
@@ -139,9 +139,9 @@ describe("search.controller.spec.unit", () => {
         });
     });
 
-    describe("check it returns a dissolved results page without an address if not available", () => {
-        it("should return a results page without the RO address", () => {
-            chai.expect(generateROAddress(emptyMockResponseBody.top_hit.registered_office_address)).to.contain("Not available");
+    describe("check it returns a dissolved results page with the address showing not available", () => {
+        it("should return a results page with the RO address showing Not available", () => {
+            chai.expect(generateROAddress(undefined)).to.contain("Not available");
         });
     });
 

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -81,7 +81,7 @@ const emptyMockResponseBody : CompaniesResource = ({
     hits: 20,
     top_hit: {
         registered_office_address: {
-            address_line_1: "",
+            address_line_1: "Not available",
             address_line_2: "",
             locality: "",
             postal_code: ""
@@ -141,7 +141,7 @@ describe("search.controller.spec.unit", () => {
 
     describe("check it returns a dissolved results page without an address if not available", () => {
         it("should return a results page without the RO address", () => {
-            chai.expect(generateROAddress(emptyMockResponseBody.top_hit.registered_office_address)).to.not.contain("test house");
+            chai.expect(generateROAddress(emptyMockResponseBody.top_hit.registered_office_address)).to.contain("Not available");
         });
     });
 

--- a/src/views/dissolved-search/previous-name-results.html
+++ b/src/views/dissolved-search/previous-name-results.html
@@ -13,6 +13,8 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Search results</h1>
     <p class="govuk-body govuk-!-width-full">You can call the Contact Centre on 0303 123 4500, or email <a href="mailto:enquiries@companieshouse.gov.uk">enquiries@companieshouse.gov.uk</a>, to find out if there is any more information available about a dissolved company.</p>
+    <p class="govuk-body govuk-!-width-full">We cannot show the registered office address if this information is missing from our records, or for companies dissolved more than 20 years ago.</p>
+
     {% if searchResults.length > 0 %}
       {{ govukTable({
         firstCellIsHeader: false,

--- a/src/views/dissolved-search/results.html
+++ b/src/views/dissolved-search/results.html
@@ -13,7 +13,8 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Search results</h1>
     <p class="govuk-body govuk-!-width-full">You can call the Contact Centre on 0303 123 4500, or email <a href="mailto:enquiries@companieshouse.gov.uk">enquiries@companieshouse.gov.uk</a>, to find out if there is any more information available about a dissolved company.</p>
-    
+    <p class="govuk-body govuk-!-width-full">We cannot show the registered office address if this information is missing from our records, or for companies dissolved more than 20 years ago.</p>
+
     {% if searchResults.length > 0 %}
       {{ govukTable ({
         firstCellIsHeader: false,


### PR DESCRIPTION
Added in a check where if all the fields are undefined it would return "Not available" 
Added text to explain to the user that the address won't show if we don't have the data or it is over 20 years dissolved. 
Fixed the test which didn't check for undefined. 

Resolves: BI-8462