### PR TITLE
Add company type to search results

### DIFF
--- a/src/config/api.enumerations.ts
+++ b/src/config/api.enumerations.ts
@@ -1,15 +1,16 @@
 import fs from "fs";
 import yaml from "js-yaml";
 
-const COMPANY_STATUS_CONSTANTS_PATH: string = "api-enumerations/constants.yml";
-const COMPANY_STATUS_CONSTANT: string = "company_status";
+const COMPANY_CONSTANTS_PATH: string = "api-enumerations/constants.yml";
+export const COMPANY_STATUS_CONSTANT: string = "company_status";
+export const COMPANY_TYPE_CONSTANT: string = "company_type";
 
-const companyStatusConstants = yaml.safeLoad(fs.readFileSync(COMPANY_STATUS_CONSTANTS_PATH, "utf8"));
+const companyConstants = yaml.safeLoad(fs.readFileSync(COMPANY_CONSTANTS_PATH, "utf8"));
 
-export const getCompanyStatusConstant = (descriptionKey: string): string => {
-    if (companyStatusConstants === undefined) {
+export const getCompanyConstant = (enumerationCategory: string, descriptionKey: string): string => {
+    if (companyConstants === undefined) {
         return descriptionKey;
     } else {
-        return companyStatusConstants[COMPANY_STATUS_CONSTANT][descriptionKey] || descriptionKey;
+        return companyConstants[enumerationCategory][descriptionKey] || descriptionKey;
     }
-};
+}

--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -3,7 +3,7 @@ import { createLogger } from "@companieshouse/structured-logging-node";
 import { SEARCH_WEB_COOKIE_NAME, API_KEY, APPLICATION_NAME } from "../../config/config";
 import { getAdvancedCompanies } from "../../client/apiclient";
 import { CompaniesResource } from "@companieshouse/api-sdk-node/dist/services/search/advanced-search/types";
-import { getCompanyStatusConstant } from "../../config/api.enumerations";
+import { getCompanyConstant, COMPANY_STATUS_CONSTANT, COMPANY_TYPE_CONSTANT } from "../../config/api.enumerations";
 import * as templatePaths from "../../model/template.paths";
 
 import Cookies = require("cookies");
@@ -39,13 +39,15 @@ const getSearchResults = async (companyNameIncludes: string | null, companyNameE
             sicCodes, companyStatus, companyType, dissolvedFrom, dissolvedTo, (cookies.get(SEARCH_WEB_COOKIE_NAME) as string));
         const { items } = companyResource;
 
-        const searchResults = items.map(({ company_name, links, company_status }) => {
-            const mappedCompanyStatus = getCompanyStatusConstant(company_status);
+        const searchResults = items.map(({ company_name, links, company_status, company_type }) => {
+            const mappedCompanyStatus = getCompanyConstant(COMPANY_STATUS_CONSTANT, company_status);
+            const mappedCompanyType = getCompanyConstant(COMPANY_TYPE_CONSTANT, company_type);
             return [
                 {
                     html: `<h2 class="govuk-heading-m" style="margin-bottom: 3px;"><a class="govuk-link" href=${links.company_profile} target="_blank">${company_name}<span class="govuk-visually-hidden">(link opens a new window)</span></a></h2>
                             <p style="padding-bottom: 10px; margin-top:0px;">
-                            <span class="govuk-body govuk-!-font-weight-bold">${mappedCompanyStatus}</span><br></p>`
+                            <span class="govuk-body govuk-!-font-weight-bold">${mappedCompanyStatus}</span><br>
+                            ${mappedCompanyType}<br></p>`
                 }
             ];
         });

--- a/src/test/config/api.enumerations.unit.test.ts
+++ b/src/test/config/api.enumerations.unit.test.ts
@@ -1,17 +1,27 @@
 import { expect } from "chai";
 
-import { getCompanyStatusConstant } from "../../config/api.enumerations";
+import { getCompanyConstant, COMPANY_STATUS_CONSTANT, COMPANY_TYPE_CONSTANT } from "../../config/api.enumerations";
 
 describe("api.enumerations.unit", () => {
-    describe("getCompanyStatusConstant", () => {
+    describe("getCompanyConstant", () => {
         it("should load the constants file from api-enumeration correctly and load data from it", () => {
-            const result = getCompanyStatusConstant("voluntary-arrangement");
+            const result = getCompanyConstant( COMPANY_STATUS_CONSTANT, "voluntary-arrangement");
             expect(result).to.equal("Voluntary Arrangement");
         });
 
         it("should return the same input passed in if company status value is not present", () => {
-            const result = getCompanyStatusConstant("actve");
+            const result = getCompanyConstant( COMPANY_STATUS_CONSTANT, "actve");
             expect(result).to.equal("actve");
+        });
+
+        it("should load the constants file from api-enumeration and load the company-type value from it", () => {
+            const result = getCompanyConstant( COMPANY_TYPE_CONSTANT, "ltd");
+            expect(result).to.equal("Private limited company");
+        });
+
+        it("should return the same input passed in if company type value is not present", () => {
+            const result = getCompanyConstant( COMPANY_TYPE_CONSTANT, "pub-ltd-comp");
+            expect(result).to.equal("pub-ltd-comp");
         });
     });
 });

--- a/src/test/controllers/advanced-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/advanced-search/search.controller.spec.unit.ts
@@ -80,6 +80,17 @@ describe("search.controller.spec.unit", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect(resp.text).to.contain("Active");
         });
+
+        it("should show the company type", async () => {
+            getCompanyItemStub = sandbox.stub(apiClient, "getAdvancedCompanies")
+                .returns(Promise.resolve(mockUtils.getDummyAdvancedCompanyResource("test")));
+
+            const resp = await chai.request(testApp)
+                .get("/advanced-search/get-results?containsCompanyName=test&excludesCompanyName=");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("Private limited company");
+        });
     });
 
     describe("check form values on results page", () => {


### PR DESCRIPTION
Refactored api enumerations constant retrieval to enable company status and company type to have a single method for retrieving api-enumeration value.
Added company type to search results

Resolves: BI-9016