### PR TITLE
Ensure branches do not show download link

### DIFF
--- a/src/controllers/dissolved-search/search.controller.ts
+++ b/src/controllers/dissolved-search/search.controller.ts
@@ -128,7 +128,7 @@ const getSearchResults = async (encodedCompanyName: string, cookies: Cookies, se
 
         const searchResults = items.map(({ company_name, company_number, date_of_cessation, date_of_creation, registered_office_address, previous_company_names, ordered_alpha_key_with_id, matched_previous_company_name }) => {
             const nearestClass = detectNearestMatch(ordered_alpha_key_with_id, top_hit.ordered_alpha_key_with_id, noNearestMatch);
-            const reportAvailable: boolean = determineReportAvailableBool(date_of_cessation);
+            const reportAvailable: boolean = determineReportAvailableBool(company_number, date_of_cessation);
             const downloadReportText: string = getDownloadReportText(signedIn, reportAvailable, returnToUrl, company_number);
 
             if (!noNearestMatch) {

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -35,7 +35,11 @@ export const sanitiseCompanyName = (companyName) => {
     return escape(companyName);
 };
 
-export const determineReportAvailableBool = (dateOfDissolution): boolean => {
+export const determineReportAvailableBool = (companyNumber: string, dateOfDissolution): boolean => {
+    if (companyNumber.substring(0, 2) === "BR") {
+        return false;
+    }
+
     const dissolutionDate = dateOfDissolution.toString();
     const now = moment();
     const nowMinus20years = now.subtract(20, "years").format("YYYY-MM-DD");

--- a/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
+++ b/src/test/controllers/dissolved-search/search.controller.spec.unit.ts
@@ -515,17 +515,28 @@ describe("search.controller.spec.unit", () => {
 
         describe("check it returns a url is the company has been dissolved less than 20 years", () => {
             it("should return a url for companies less than 20 years", () => {
+                const companyNumber = "00000000";
                 const date = "2010";
 
-                chai.expect(determineReportAvailableBool(date)).to.equal(true);
+                chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(true);
+            });
+        });
+
+        describe("check it does not return a url if the company is a branch", () => {
+            it("should return a url for companies less than 20 years", () => {
+                const companyNumber = "BR000000";
+                const date = "2010";
+
+                chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(false);
             });
         });
 
         describe("check it does not return a url is the company has been dissolved more than 20 years", () => {
             it("should not return a url for companies more than 20 years", () => {
+                const companyNumber = "00000000";
                 const date = "1990";
 
-                chai.expect(determineReportAvailableBool(date)).to.equal(false);
+                chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(false);
             });
         });
     });

--- a/src/test/controllers/utils.spec.unit.ts
+++ b/src/test/controllers/utils.spec.unit.ts
@@ -5,14 +5,22 @@ import { checkLineBreakRequired, determineReportAvailableBool, getDownloadReport
 describe("utils.spec.unit", () => {
     describe("check that reports are only available if within the last 20 years", () => {
         it("should return false if date is > 20 years old", () => {
+            const companyNumber: string = "00000000";
             const date: string = "1990-00-25";
 
-            chai.expect(determineReportAvailableBool(date)).to.equal(false);
+            chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(false);
         });
         it("should return true if date is < 20 years old", () => {
+            const companyNumber: string = "00000000";
             const date: string = "2009-00-25";
 
-            chai.expect(determineReportAvailableBool(date)).to.equal(true);
+            chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(true);
+        });
+        it("should return false if the company number starts with BR branches", () => {
+            const companyNumber: string = "BR000000";
+            const date: string = "2009-00-25";
+
+            chai.expect(determineReportAvailableBool(companyNumber, date)).to.equal(false);
         });
     });
 


### PR DESCRIPTION
Branches can currently show a download report link but this is not something that we wish to display for these companies.