### PR TITLE
BI-9477 - Remove duplicate ID that is already being generated by nunjucks template

### DIFF
--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -116,86 +116,84 @@
                 content: {
                   html: "
                     <fieldset class='govuk-fieldset'>
-                          <div class='govuk-form-group'>  
-                              <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
-                                <fieldset class='govuk-fieldset'>
-                                  <div class='govuk-checkboxes--small'>
-
-                                  <div class='govuk-checkboxes__item'>
-                                    <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active'>
-                                    <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
-                                      Active
-                                    </label>
-                                  </div>
-
-                                  <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
-                                        Dissolved
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
-                                        Open
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
-                                        Closed
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
-                                        Converted closed
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
-                                        Receivership
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
-                                        Liquidation
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
-                                        Administration
-                                      </label>
-                                    </div>
-
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
-                                        Insolvency proceedings
-                                      </label>
-                                    </div>
-
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
-                                        Voluntary arrangement
-                                      </label>
-                                    </div>
-
-                                </div>
-                                </fieldset>
+                      <div class='govuk-form-group'>
+                        <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
+                          <fieldset class='govuk-fieldset'>
+                            <div class='govuk-checkboxes--small'>
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active'>
+                                <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
+                                  Active
+                                </label>
                               </div>
-                          </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                  <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved'>
+                                  <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
+                                    Dissolved
+                                  </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open'>
+                                <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
+                                  Open
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed'>
+                                <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
+                                  Closed
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed'>
+                                <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
+                                  Converted closed
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership'>
+                                <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
+                                  Receivership
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation'>
+                                <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
+                                  Liquidation
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration'>
+                                <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
+                                  Administration
+                                </label>
+                              </div>
+
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings'>
+                                <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
+                                  Insolvency proceedings
+                                </label>
+                              </div>
+
+                              <div class='govuk-checkboxes__item'>
+                                <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement'>
+                                <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
+                                  Voluntary arrangement
+                                </label>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </div>
+                      </div>
                     </fieldset>"
                 }
               }

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -117,85 +117,83 @@
                   html: "
                     <fieldset class='govuk-fieldset'>
                           <div class='govuk-form-group'>  
-                            <div id='accordion-default-content-3' class='govuk-accordion__section-content' aria-labelledby='accordion-default-heading-3'>
-                                <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
-                                  <fieldset class='govuk-fieldset'>
-                                    <div class='govuk-checkboxes--small'>
+                              <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
+                                <fieldset class='govuk-fieldset'>
+                                  <div class='govuk-checkboxes--small'>
 
-                                    <div class='govuk-checkboxes__item'>
-                                      <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active'>
-                                      <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
-                                        Active
+                                  <div class='govuk-checkboxes__item'>
+                                    <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active'>
+                                    <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
+                                      Active
+                                    </label>
+                                  </div>
+
+                                  <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
+                                        Dissolved
                                       </label>
                                     </div>
 
                                     <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
-                                          Dissolved
-                                        </label>
-                                      </div>
+                                      <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
+                                        Open
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
-                                          Open
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
+                                        Closed
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
-                                          Closed
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
+                                        Converted closed
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
-                                          Converted closed
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
+                                        Receivership
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
-                                          Receivership
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
+                                        Liquidation
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
-                                          Liquidation
-                                        </label>
-                                      </div>
-
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
-                                          Administration
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
+                                        Administration
+                                      </label>
+                                    </div>
 
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
-                                          Insolvency proceedings
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
+                                        Insolvency proceedings
+                                      </label>
+                                    </div>
 
-                                      <div class='govuk-checkboxes__item'>
-                                        <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement'>
-                                        <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
-                                          Voluntary arrangement
-                                        </label>
-                                      </div>
+                                    <div class='govuk-checkboxes__item'>
+                                      <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement'>
+                                      <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
+                                        Voluntary arrangement
+                                      </label>
+                                    </div>
 
-                                  </div> 
-                                  </fieldset>
                                 </div>
+                                </fieldset>
                               </div>
                           </div>
                     </fieldset>"

--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -135,81 +135,79 @@
 
   {% set statusFormHtml %}
   <div class='govuk-form-group'>
-      <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 300px; padding-left: govuk-spacing(1);'>
-          <fieldset class='govuk-fieldset'>
-            <div class='govuk-checkboxes--small'>
-
-            <div class='govuk-checkboxes__item'>
-              <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active' {{ selectedStatusCheckboxes.active }}>
-              <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
-                Active
-              </label>
-            </div>
-
-            <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved' {{ selectedStatusCheckboxes.dissolved }}>
-                <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
-                  Dissolved
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open' {{ selectedStatusCheckboxes.open }}>
-                <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
-                  Open
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed' {{  selectedStatusCheckboxes.closed }}>
-                <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
-                  Closed
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed' {{selectedStatusCheckboxes.convertedClosed }}>
-                <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
-                  Converted closed
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership' {{ selectedStatusCheckboxes.receivership }}>
-                <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
-                  Receivership
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation' {{ selectedStatusCheckboxes.liquidation }}>
-                <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
-                  Liquidation
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration' {{ selectedStatusCheckboxes.administration }}>
-                <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
-                  Administration
-                </label>
-              </div>
-
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings' {{ selectedStatusCheckboxes.insolvencyProceedings }}>
-                <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
-                  Insolvency proceedings
-                </label>
-              </div>
-
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement' {{  selectedStatusCheckboxes.voluntaryArrangement }}>
-                <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
-                  Voluntary arrangement
-                </label>
-              </div>
+    <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 300px; padding-left: govuk-spacing(1);'>
+      <fieldset class='govuk-fieldset'>
+        <div class='govuk-checkboxes--small'>
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active' {{ selectedStatusCheckboxes.active }}>
+            <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
+              Active
+            </label>
           </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved' {{ selectedStatusCheckboxes.dissolved }}>
+            <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
+              Dissolved
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open' {{ selectedStatusCheckboxes.open }}>
+            <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
+              Open
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed' {{  selectedStatusCheckboxes.closed }}>
+            <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
+              Closed
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed' {{selectedStatusCheckboxes.convertedClosed }}>
+            <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
+              Converted closed
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership' {{ selectedStatusCheckboxes.receivership }}>
+            <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
+              Receivership
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation' {{ selectedStatusCheckboxes.liquidation }}>
+            <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
+              Liquidation
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration' {{ selectedStatusCheckboxes.administration }}>
+            <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
+              Administration
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings' {{ selectedStatusCheckboxes.insolvencyProceedings }}>
+            <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
+              Insolvency proceedings
+            </label>
+          </div>
+
+          <div class='govuk-checkboxes__item'>
+            <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement' {{  selectedStatusCheckboxes.voluntaryArrangement }}>
+            <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
+              Voluntary arrangement
+            </label>
+          </div>
+        </div>
       </fieldset>
     </div>
   </div>

--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -135,84 +135,82 @@
 
   {% set statusFormHtml %}
   <div class='govuk-form-group'>
-    <div id='accordion-default-content-3' class='govuk-accordion__section-content' aria-labelledby='accordion-default-heading-3'>
-        <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 300px; padding-left: govuk-spacing(1);'>
-            <fieldset class='govuk-fieldset'>
-              <div class='govuk-checkboxes--small'>
+      <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 300px; padding-left: govuk-spacing(1);'>
+          <fieldset class='govuk-fieldset'>
+            <div class='govuk-checkboxes--small'>
 
-              <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active' {{ selectedStatusCheckboxes.active }}>
-                <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
-                  Active
+            <div class='govuk-checkboxes__item'>
+              <input class='govuk-checkboxes__input' id='activeCompanies' name='status' type='checkbox' value='active' {{ selectedStatusCheckboxes.active }}>
+              <label class='govuk-label govuk-checkboxes__label' for='activeCompanies'>
+                Active
+              </label>
+            </div>
+
+            <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved' {{ selectedStatusCheckboxes.dissolved }}>
+                <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
+                  Dissolved
                 </label>
               </div>
 
               <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='dissolvedCompanies' name='status' type='checkbox' value='dissolved' {{ selectedStatusCheckboxes.dissolved }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='dissolvedCompanies'>
-                    Dissolved
-                  </label>
-                </div>
+                <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open' {{ selectedStatusCheckboxes.open }}>
+                <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
+                  Open
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='openCompanies' name='status' type='checkbox' value='open' {{ selectedStatusCheckboxes.open }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='openCompanies'>
-                    Open
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed' {{  selectedStatusCheckboxes.closed }}>
+                <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
+                  Closed
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='closedCompanies' name='status' type='checkbox' value='closed' {{  selectedStatusCheckboxes.closed }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='closedCompanies'>
-                    Closed
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed' {{selectedStatusCheckboxes.convertedClosed }}>
+                <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
+                  Converted closed
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='convertedClosedCompanies' name='status' type='checkbox' value='converted-closed' {{selectedStatusCheckboxes.convertedClosed }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='convertedClosedCompanies'>
-                    Converted closed
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership' {{ selectedStatusCheckboxes.receivership }}>
+                <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
+                  Receivership
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='receivershipCompanies' name='status' type='checkbox' value='receivership' {{ selectedStatusCheckboxes.receivership }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='receivershipCompanies'>
-                    Receivership
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation' {{ selectedStatusCheckboxes.liquidation }}>
+                <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
+                  Liquidation
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='liquidationCompanies' name='status' type='checkbox' value='liquidation' {{ selectedStatusCheckboxes.liquidation }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='liquidationCompanies'>
-                    Liquidation
-                  </label>
-                </div>
-
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration' {{ selectedStatusCheckboxes.administration }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
-                    Administration
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='administrationCompanies' name='status' type='checkbox' value='administration' {{ selectedStatusCheckboxes.administration }}>
+                <label class='govuk-label govuk-checkboxes__label' for='administrationCompanies'>
+                  Administration
+                </label>
+              </div>
 
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings' {{ selectedStatusCheckboxes.insolvencyProceedings }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
-                    Insolvency proceedings
-                  </label>
-                </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='insolvencyProceedingsCompanies' name='status' type='checkbox' value='insolvency-proceedings' {{ selectedStatusCheckboxes.insolvencyProceedings }}>
+                <label class='govuk-label govuk-checkboxes__label' for='insolvencyProceedingsCompanies'>
+                  Insolvency proceedings
+                </label>
+              </div>
 
-                <div class='govuk-checkboxes__item'>
-                  <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement' {{  selectedStatusCheckboxes.voluntaryArrangement }}>
-                  <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
-                    Voluntary arrangement
-                  </label>
-                </div>
-            </div>
-        </fieldset>
-      </div>
+              <div class='govuk-checkboxes__item'>
+                <input class='govuk-checkboxes__input' id='voluntaryArrangementCompanies' name='status' type='checkbox' value='voluntary-arrangement' {{  selectedStatusCheckboxes.voluntaryArrangement }}>
+                <label class='govuk-label govuk-checkboxes__label' for='voluntaryArrangementCompanies'>
+                  Voluntary arrangement
+                </label>
+              </div>
+          </div>
+      </fieldset>
     </div>
   </div>
 {% endset %}


### PR DESCRIPTION
Duplicate ID present - ID removed as it is being generated by nunjucks and reformat the html for the removal of the element.
Resolves: BI-9477