### PR TITLE
Add missing helptext to results page

### DIFF
--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -232,6 +232,9 @@
       <label class='accordion-label padded-top' for='sicCodes'>
         Enter a Standard Industrial Classification (SIC) code to search by nature of business.
       </label>
+      <div id='sic-hint' class='accordion-hint'>
+        For example, 01120
+      </div>
 
       <input class='govuk-input govuk-!-width-full' id='sicCodes' name='sicCodes' type='text' value='{{ advancedSearchParams.sicCodes }}'>
 


### PR DESCRIPTION
Add helptext that is present on the initial search screen to the results page.