### PR TITLE
GCI-1947 - Point at latest api-sdk-node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -338,9 +338,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.78",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.78.tgz",
-      "integrity": "sha512-MHLw9u9pzQITD0oiCxYR5S34/w0vl2CswH0KoHSFY2GARyIt5XxeDd8gfZHnkR8NeXEozwGifTjiH8EPD+1D1g==",
+      "version": "1.0.82",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.82.tgz",
+      "integrity": "sha512-v+y8v5m4H7vu0HO71HKxKAYEhC/YeaYdcr/wLSxYZ/tNdnaWXtHtAJ4bB6aLOhWnkRrX1W9iVSNulFEjoUXJmw==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "1.0.78",
+    "@companieshouse/api-sdk-node": "1.0.82",
     "@companieshouse/node-session-handler": "~4.1.6",
     "@companieshouse/structured-logging-node": "1.0.4",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Required as latest version updates the API endpoint from `/enhanced-search` to `advanced-search`
Resolves: GCI-1947