### PR TITLE
Fix search terms displaying in chrome and IE

### DIFF
--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -16,6 +16,9 @@
 
 {% block content %}
 
+{# reloads the page if the user uses the navigation buttons in chrome or IE, the search fields will be populated correctly with the queries #}
+<script>reloadPage()</script>
+
 <div class="govuk-width-container">
 
     <div class="govuk-grid-row">

--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -17,6 +17,9 @@
 
 {% block content %}
 
+{# reloads the page if the user uses the navigation buttons in chrome or IE, the search fields will be populated correctly with the queries #}
+<script>reloadPage()</script>
+
   {% if errorList.length > 0 %}
     {{ govukErrorSummary({
       titleText: ERROR_SUMMARY_TITLE,

--- a/static/js/matcher.js
+++ b/static/js/matcher.js
@@ -36,3 +36,14 @@ function clearForm(form) {
     };
   };
 };
+
+function reloadPage() {
+    if (navigator.userAgent.indexOf("Chrome") !== -1 || navigator.userAgent.indexOf('Trident/') !== -1){
+      window.addEventListener( "pageshow", function ( event ) {
+        let historyTraversal = event.persisted || window.performance.getEntriesByType("navigation")[0].type === "back_forward";
+        if (historyTraversal) {
+          window.location.reload();
+        };
+      });
+    };
+};


### PR DESCRIPTION
add function to reload page if navigation buttons used in chrome or IE to display correct values in search fields

Resolves: BI-9508