### PR TITLE
BI-9939 Extend width of results table

### DIFF
--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -650,7 +650,7 @@
         {% if searchResults.length > 0 %}
           {{ govukTable ({
               rows: searchResults,
-              classes: 'govuk-!-font-size-16 govuk-!-width-one-half'
+              classes: 'govuk-!-font-size-16'
           }) }}
 
           {% if numberOfPages > 1 %}


### PR DESCRIPTION
BI-9939
Increase the width of the results table to be 100% of the space in the containing div