### PR TITLE
fix paging advanced search

### DIFF
--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -10,6 +10,8 @@ import { ADVANCED_SEARCH_NUMBER_OF_RESULTS_TO_DOWNLOAD } from "../../config/conf
 import Cookies = require("cookies");
 
 const route = async (req: Request, res: Response) => {
+    //Elastic search returns a maximum of 10,000 company profiles in the resource
+    const ELASTIC_SEARCH_MAX_RESULTS = 10000;
     const cookies = new Cookies(req, res);
     const page = req.query.page ? Number(req.query.page) : 1;
     const { fullDissolvedDates, fullIncorporationDates } = getDatesFromParams(req);
@@ -47,7 +49,8 @@ const route = async (req: Request, res: Response) => {
     const { companyResource, searchResults } = await getSearchResults(advancedSearchParams, cookies);
     const totalReturnedHits: number = companyResource.hits;
     const totalReturnedHitsFormatted: string = companyResource.hits.toLocaleString();
-    const numberOfPages: number = Math.ceil(companyResource.hits / 20);
+    const maximumDisplayableResults = totalReturnedHits <= ELASTIC_SEARCH_MAX_RESULTS ? totalReturnedHits : ELASTIC_SEARCH_MAX_RESULTS;
+    const numberOfPages: number = Math.ceil(maximumDisplayableResults / 20);
     const pagingRange = getPagingRange(page, numberOfPages);
     const partialHref: string = buildPagingUrl(advancedSearchParams, incorporationDates, dissolvedDates);
 

--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -10,7 +10,7 @@ import { ADVANCED_SEARCH_NUMBER_OF_RESULTS_TO_DOWNLOAD } from "../../config/conf
 import Cookies = require("cookies");
 
 const route = async (req: Request, res: Response) => {
-    //Elastic search returns a maximum of 10,000 company profiles in the resource
+    // Elastic search returns a maximum of 10,000 company profiles in the resource
     const ELASTIC_SEARCH_MAX_RESULTS = 10000;
     const cookies = new Cookies(req, res);
     const page = req.query.page ? Number(req.query.page) : 1;

--- a/test/controllers/advanced-search/search.controller.test.ts
+++ b/test/controllers/advanced-search/search.controller.test.ts
@@ -528,6 +528,20 @@ describe("search.controller.test", () => {
             chai.expect(resp.text).to.not.contain("page-4");
         });
 
+        it("should not display any pages beyond 500 due to max ES resource of 10000 company profiles", async () => {
+            const resourceWithHighHits = mockUtils.getDummyAdvancedCompanyResource("test", 50);
+            resourceWithHighHits.hits = 20000;
+            getCompanyItemStub = sandbox.stub(apiClient, "getAdvancedCompanies")
+                .returns(Promise.resolve(resourceWithHighHits));
+
+            const resp = await chai.request(testApp)
+                .get("/advanced-search/get-results?companyNameIncludes=test&page=500");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("<span class=\"active\">500</span>");
+            chai.expect(resp.text).to.not.contain("page-501");
+        });
+
         it("should check that the correct css class is assigned to the current page", async () => {
             getCompanyItemStub = sandbox.stub(apiClient, "getAdvancedCompanies")
                 .returns(Promise.resolve(mockUtils.getDummyAdvancedCompanyResource("test", 50)));


### PR DESCRIPTION
fix paging by using the 10,000 max company profile resource from ES rather than the total hits found

Resolves: BI-10640