### PR TITLE
ensure that responsive table css file is only available to dissolved 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -68,13 +68,11 @@ app.use((req, res, next) => {
     if (req.path.includes("/alphabetical-search")) {
         env.addGlobal("SERVICE_NAME", ALPHABETICAL_SERVICE_NAME);
         env.addGlobal("PIWIK_SERVICE_NAME", PIWIK_ALPHABETICAL_SERVICE_NAME);
-        env.addGlobal("RESPONSIVE_TABLE", "");
         env.addGlobal("BACK_LINK", ALPHABETICAL_ROOT);
         env.addGlobal("FEEDBACK_SOURCE", ALPHABETICAL_FEEDBACK_SOURCE);
     } else if (req.path.includes("/dissolved-search")) {
         env.addGlobal("SERVICE_NAME", DISSOLVED_SERVICE_NAME);
         env.addGlobal("PIWIK_SERVICE_NAME", PIWIK_DISSOLVED_SERVICE_NAME);
-        env.addGlobal("RESPONSIVE_TABLE", "/search-assets/static/responsive-table.css");
         env.addGlobal("BACK_LINK", DISSOLVED_ROOT);
         env.addGlobal("FEEDBACK_SOURCE", DISSOLVED_FEEDBACK_SOURCE);
     } else if (req.path.includes("/advanced-search")) {

--- a/src/views/base.html
+++ b/src/views/base.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" type="text/css" media="all" href="{{ CSS_URL }}" />
     <link rel="stylesheet" type="text/css" media="all" href="{{ ALPHABETICAL_SEARCH }}" />
     <link rel="stylesheet" type="text/css" media="all" href="{{ NUMBERED_PAGING }}" />
-    <link rel="stylesheet" type="text/css" media="all" href="{{ RESPONSIVE_TABLE }}" />
     <!--<![endif]-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="{{ MATCHER }}"></script>

--- a/src/views/dissolved-search/previous-name-results.html
+++ b/src/views/dissolved-search/previous-name-results.html
@@ -14,6 +14,8 @@
     }) }}
 {% endblock %}
 {% block content %}
+<link rel="stylesheet" type="text/css" media="all" href="/search-assets/static/responsive-table.css" />
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <noscript>

--- a/src/views/dissolved-search/results.html
+++ b/src/views/dissolved-search/results.html
@@ -16,6 +16,7 @@
 {% endblock %}
 
 {% block content %}
+<link rel="stylesheet" type="text/css" media="all" href="/search-assets/static/responsive-table.css" />
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
The responsive table css file is incorrectly loading intermittently for other journeys in search web other than the intended dissolved search, this is causing styling issues for advanced search results in mobile view. This change ensures this file is only available on the dissolved search results pages.

Resolves: BI-10718