### PR TITLE
BI-10796: Start search page company subtype

### DIFF
--- a/src/service/advanced-search/search.service.ts
+++ b/src/service/advanced-search/search.service.ts
@@ -101,6 +101,7 @@ export const isAdvancedSearchParamsEmpty = (advancedSearchParams: AdvancedSearch
         advancedSearchParams.sicCodes === null &&
         advancedSearchParams.companyStatus === null &&
         advancedSearchParams.companyType === null &&
+        advancedSearchParams.companySubtype === null &&
         advancedSearchParams.dissolvedFrom === null &&
         advancedSearchParams.dissolvedTo === null;
 };

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -478,6 +478,39 @@
               },
               {
                 heading: {
+                  text: "Company subtype"
+                },
+                content: {
+                  html: "
+                    <fieldset class='govuk-fieldset'>
+                    <div class='govuk-form-group'>
+                      <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
+                        <fieldset class='govuk-fieldset'>
+                          <div class='govuk-checkboxes--small'>
+
+                            <div class='govuk-checkboxes__item'>
+                              <input class='govuk-checkboxes__input' id='community-interest-company' name='subtype' type='checkbox' value='community-interest-company'>
+                              <label class='govuk-label govuk-checkboxes__label' for='community-interest-company'>
+                                Community interest company
+                              </label>
+                            </div>
+
+                            <div class='govuk-checkboxes__item'>
+                              <input class='govuk-checkboxes__input' id='private-fund-limited-partnership' name='subtype' type='checkbox' value='private-fund-limited-partnership'>
+                              <label class='govuk-label govuk-checkboxes__label' for='private-fund-limited-partnership'>
+                                Private fund limited partnership
+                              </label>
+                            </div>
+
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </fieldset>"
+                }
+              },
+              {
+                heading: {
                   text: "Dissolved date"
                 },
                 content: {

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -483,7 +483,6 @@
                 content: {
                   html: "
                     <fieldset class='govuk-fieldset'>
-                    <div class='govuk-form-group'>
                       <div class='govuk-form-group' style='overflow: scroll; height: 80px; width: 623px; padding-left: 5px;'>
                         <fieldset class='govuk-fieldset'>
                           <div class='govuk-checkboxes--small'>
@@ -505,7 +504,6 @@
                           </div>
                         </fieldset>
                       </div>
-                    </div>
                   </fieldset>"
                 }
               },

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -483,7 +483,7 @@
                 content: {
                   html: "
                     <fieldset class='govuk-fieldset'>
-                      <div class='govuk-form-group' style='overflow: scroll; height: 80px; width: 623px; padding-left: 5px;'>
+                      <div class='govuk-form-group'>
                         <fieldset class='govuk-fieldset'>
                           <div class='govuk-checkboxes--small'>
 

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -484,7 +484,7 @@
                   html: "
                     <fieldset class='govuk-fieldset'>
                     <div class='govuk-form-group'>
-                      <div class='govuk-form-group' style='overflow: scroll; height: 200px; width: 623px; padding-left: 5px;'>
+                      <div class='govuk-form-group' style='overflow: scroll; height: 80px; width: 623px; padding-left: 5px;'>
                         <fieldset class='govuk-fieldset'>
                           <div class='govuk-checkboxes--small'>
 


### PR DESCRIPTION
* Add a company subtype section to the start search page accordion.
* Currently does not feature a scrollbar for the section as it only contains 2 checkboxes.