### PR TITLE
Add missing subtype param to the paging url builder

### DIFF
--- a/src/controllers/utils/utils.ts
+++ b/src/controllers/utils/utils.ts
@@ -338,6 +338,7 @@ export const buildPagingUrl = (advancedSearchParams: AdvancedSearchParams, incor
     urlAppender(pagingUrlBuilder, advancedSearchParams.companyStatus, "status");
     urlAppender(pagingUrlBuilder, advancedSearchParams.sicCodes, "sicCodes");
     urlAppender(pagingUrlBuilder, companyTypeCheck, "type");
+    urlAppender(pagingUrlBuilder, advancedSearchParams.companySubtype, "subtype");
     urlAppender(pagingUrlBuilder, dissolvedDates.dissolvedFromDay, "dissolvedFromDay");
     urlAppender(pagingUrlBuilder, dissolvedDates.dissolvedFromMonth, "dissolvedFromMonth");
     urlAppender(pagingUrlBuilder, dissolvedDates.dissolvedFromYear, "dissolvedFromYear");

--- a/test/controllers/utils.test.ts
+++ b/test/controllers/utils.test.ts
@@ -225,7 +225,25 @@ describe("utils.test", () => {
         });
 
         it("should return a url with a parameter for all fields present", () => {
-            const searchParams = createDummyAdvancedSearchParams("1", "testCompanyNameIncludes", "testCompanyNameExcludes", "testRegisteredOfficeAddress", "testIncorporatedFrom", "testIncorporatedTo", "07210", "active", "ltd", null, "testDissolvedFromDay", "testDissolvedFromMonth", "testDissolvedFromYear", "testDissolvedToDay", "testDissolvedToMonth", "testDissolvedToYear", null);
+            const searchParams = createDummyAdvancedSearchParams(
+                "1",
+                "testCompanyNameIncludes",
+                "testCompanyNameExcludes",
+                "testRegisteredOfficeAddress",
+                "testIncorporatedFrom",
+                "testIncorporatedTo",
+                "07210",
+                "active",
+                "ltd",
+                "community-interest-company",
+                "testDissolvedFromDay",
+                "testDissolvedFromMonth",
+                "testDissolvedFromYear",
+                "testDissolvedToDay",
+                "testDissolvedToMonth",
+                "testDissolvedToYear",
+                null
+            );
             chai.expect(buildPagingUrl(searchParams, incorporationDates, dissolvedDates))
                 .to.equal("get-results?companyNameIncludes=testCompanyNameIncludes" +
                     "&companyNameExcludes=testCompanyNameExcludes" +
@@ -239,6 +257,7 @@ describe("utils.test", () => {
                     "&status=active" +
                     "&sicCodes=07210" +
                     "&type=ltd" +
+                    "&subtype=community-interest-company" +
                     "&dissolvedFromDay=testDissolvedFromDay" +
                     "&dissolvedFromMonth=testDissolvedFromMonth" +
                     "&dissolvedFromYear=testDissolvedFromYear" +


### PR DESCRIPTION
Add subtype url parameter to the paging url builder so that the subtype filter remains when paging.