### PR TITLE
add dynamic matomo event id for roe download results add event id to …

### DIFF
--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -67,6 +67,9 @@ const route = async (req: Request, res: Response) => {
     const numberOfPages: number = Math.ceil(maximumDisplayableResults / 20);
     const pagingRange = getPagingRange(page, numberOfPages);
     const partialHref: string = buildPagingUrl(advancedSearchParams, incorporationDates, dissolvedDates);
+    console.log(advancedSearchParams.companyType)
+    const downloadResultsMatomoEventId: string = advancedSearchParams.companyType === "registered-overseas-entity" ? 
+        "advanced-search-results-page-roe-download-results" : "advanced-search-results-page-download-results";
 
     return res.render(templatePaths.ADVANCED_SEARCH_RESULTS, {
         ...dissolvedDates,
@@ -82,7 +85,8 @@ const route = async (req: Request, res: Response) => {
         selectedSubtypeCheckboxes,
         ADV_SEARCH_NUM_OF_RESULTS_TO_DOWNLOAD,
         totalReturnedHitsFormatted,
-        totalReturnedHits
+        totalReturnedHits,
+        downloadResultsMatomoEventId
     });
 };
 

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -122,7 +122,7 @@
 
             {% if ROE_FEATURE_FLAG === "1" %}
               <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='registered-overseas-entity' name='type' type='checkbox' value='registered-overseas-entity'>
+                <input class='govuk-checkboxes__input' id='registered-overseas-entity' name='type' type='checkbox' value='registered-overseas-entity' data-event-id='advanced-search-overseas-entity-selected-start-page'>
                 <label class='govuk-label govuk-checkboxes__label' for='registered-overseas-entity'>
                   Overseas entity
                 </label>

--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -555,7 +555,7 @@
 
             {% if ROE_FEATURE_FLAG === "1" %}
               <div class='govuk-checkboxes__item'>
-                <input class='govuk-checkboxes__input' id='registered-overseas-entity' name='type' type='checkbox' value='registered-overseas-entity' {{ selectedTypeCheckboxes.registeredOverseasEntity }}>
+                <input class='govuk-checkboxes__input' id='registered-overseas-entity' name='type' type='checkbox' value='registered-overseas-entity' {{ selectedTypeCheckboxes.registeredOverseasEntity }} data-event-id='advanced-search-overseas-entity-selected-results-page'>
                 <label class='govuk-label govuk-checkboxes__label' for='registered-overseas-entity'>
                   Overseas entity
                 </label>

--- a/src/views/components/download-results.html
+++ b/src/views/components/download-results.html
@@ -75,7 +75,7 @@
                 </div>
             {% endif %}
             <div class="govuk-button-group download-button">
-                <button class="govuk-button" data-module="govuk-button" data-event-id="advanced-search-results-page-download-results">
+                <button class="govuk-button" data-module="govuk-button" data-event-id={{downloadResultsMatomoEventId}}>
                 Download results
                 </button>
             </div>


### PR DESCRIPTION
add dynamic matomo event id for roe download results when only overseas entity is selected for company type
add event id to company type overseas entity advanced search selection on start page and results page