### PR TITLE
Amendments to enable screen readers on dissolved company search results

### DIFF
--- a/src/controllers/utils/utils.ts
+++ b/src/controllers/utils/utils.ts
@@ -214,8 +214,8 @@ export const generateSize = (size: string | null, searchBefore: string | null, s
 };
 
 export const mapResponsiveHeaders = (fieldHeading : string, fieldValue : string): string => {
-    return "<span class=\"responsive-table__heading\" aria-hidden=\"true\">" + fieldHeading + "</span>" +
-    "<span class=\"responsive-table__cell\" aria-hidden=\"true\">" + fieldValue + "</span>";
+    return "<span class=\"responsive-table__heading\" aria-hidden=\"false\">" + fieldHeading + "</span>" +
+    "<span class=\"responsive-table__cell\" aria-hidden=\"false\">" + fieldValue + "</span>";
 };
 
 export const formatLongDate = (message: string, date: Date | null | undefined): string => {

--- a/src/views/dissolved-search/results.html
+++ b/src/views/dissolved-search/results.html
@@ -63,7 +63,7 @@
             },
             {
               text: "Download Report",
-              classes: 'govuk-!-font-size-16 govuk-link'
+              classes: 'govuk-!-font-size-16'
             }
           ],
           rows: searchResults,

--- a/test/controllers/utils.test.ts
+++ b/test/controllers/utils.test.ts
@@ -60,8 +60,8 @@ describe("utils.test", () => {
 
     describe("check that the mapResponsiveHeaders returns the correct string of html", () => {
         it("should return a html string which includes the field name and field value", () => {
-            const expectedString = "<span class=\"responsive-table__heading\" aria-hidden=\"true\">Company name</span>" +
-            "<span class=\"responsive-table__cell\" aria-hidden=\"true\">Test Company</span>";
+            const expectedString = "<span class=\"responsive-table__heading\" aria-hidden=\"false\">Company name</span>" +
+            "<span class=\"responsive-table__cell\" aria-hidden=\"false\">Test Company</span>";
 
             chai.expect(mapResponsiveHeaders("Company name", "Test Company")).to.equal(expectedString);
         });


### PR DESCRIPTION
Amendments to enable screen readers to pick up the contents of the table of search results.
Additional removal of style class from table header as the table header is not a link.

BI-11374
BI-11375