### PR TITLE
BI-13693 - Add Country to registered officer address advanced search download results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-20
 WORKDIR /opt
 COPY api-enumerations ./api-enumerations
-COPY dist ./package.json ./package-lock.json docker_start.sh ./
 COPY node_modules ./node_modules
+COPY ./package.json ./package-lock.json docker_start.sh dist ./
 
 CMD ["./docker_start.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-20
 WORKDIR /opt
 COPY api-enumerations ./api-enumerations
+COPY dist ./package.json ./package-lock.json docker_start.sh ./
 COPY node_modules ./node_modules
-COPY ./package.json ./package-lock.json docker_start.sh dist ./
 
 CMD ["./docker_start.sh"]
 

--- a/src/controllers/utils/utils.ts
+++ b/src/controllers/utils/utils.ts
@@ -108,6 +108,7 @@ export const generateROAddress = (registered_office_address) => {
     let addressLine2 = "";
     let town = "";
     let postCode = "";
+    let country = "";
 
     if (registered_office_address?.address_line_1 !== undefined) {
         addressLine1 = registered_office_address?.address_line_1 + " ";
@@ -125,12 +126,16 @@ export const generateROAddress = (registered_office_address) => {
         postCode = registered_office_address?.postal_code;
     }
 
+    if (registered_office_address?.country !== undefined) {
+        postCode = registered_office_address?.country;
+    }
+
     if (registered_office_address?.address_line_1 === undefined && registered_office_address?.address_line_2 === undefined &&
-        registered_office_address?.locality === undefined && registered_office_address?.postal_code === undefined) {
+        registered_office_address?.locality === undefined && registered_office_address?.postal_code === undefined && registered_office_address?.country === undefined) {
         addressLine1 = "Not available";
     }
 
-    return addressLine1 + addressLine2 + town + postCode;
+    return addressLine1 + addressLine2 + town + postCode + country;
 };
 
 export const formatDate = (unformattedDate) => {

--- a/src/controllers/utils/utils.ts
+++ b/src/controllers/utils/utils.ts
@@ -123,11 +123,11 @@ export const generateROAddress = (registered_office_address) => {
     }
 
     if (registered_office_address?.postal_code !== undefined) {
-        postCode = registered_office_address?.postal_code;
+        postCode = registered_office_address?.postal_code + " ";
     }
 
     if (registered_office_address?.country !== undefined) {
-        postCode = registered_office_address?.country;
+        country = registered_office_address?.country;
     }
 
     if (registered_office_address?.address_line_1 === undefined && registered_office_address?.address_line_2 === undefined &&

--- a/test/controllers/utils.test.ts
+++ b/test/controllers/utils.test.ts
@@ -459,7 +459,7 @@ describe("utils.test", () => {
             chai.expect(mappedCompanies[0].incorporation_date).to.deep.equal(new Date(1980, 13, 8));
             chai.expect(mappedCompanies[0].removed_date).to.deep.equal("");
             chai.expect(mappedCompanies[0].registered_date).to.deep.equal("");
-            chai.expect(mappedCompanies[0].registered_office_address).to.equal("test house test street cardiff cf5 6rb");
+            chai.expect(mappedCompanies[0].registered_office_address).to.equal("test house test street cardiff cf5 6rb country");
             chai.expect(mappedCompanies[1].company_name).to.equal("test1");
             chai.expect(mappedCompanies[1].company_status).to.equal("Removed");
             chai.expect(mappedCompanies[1].company_type).to.equal("Overseas entity");


### PR DESCRIPTION
Fulfils [BI13693](https://companieshouse.atlassian.net/browse/BI-13693)

Test search term used locally: TEST OE

Search results:

![test oe company search](https://github.com/companieshouse/search.web.ch.gov.uk/assets/95215074/386554ce-bff1-4139-82f2-bbd4e3195b13)

Downloaded CSV results of above search, with country now included in registered_office_address box:

![csv download results](https://github.com/companieshouse/search.web.ch.gov.uk/assets/95215074/0d90e60a-a20f-4b62-826f-a56ca655a8bb)
