### PR TITLE
GURB-4 - Keep package.json in production image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 	cp -r ./package.json $(tmpdir)
 	cp -r ./package-lock.json $(tmpdir)
 	cd $(tmpdir) && npm i --production
-	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
+	rm $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .
 	rm -rf $(tmpdir)
 


### PR DESCRIPTION
This is used by the getGOVUKFrontendVersion utility to keep the template and local version of govuk-frontend in alignment.