### PR TITLE
Fix cookie banner paragraphs being unstyled

### DIFF
--- a/src/views/components/cookie-consent-banner.html
+++ b/src/views/components/cookie-consent-banner.html
@@ -4,8 +4,8 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Companies House services</h2>
         <div class="govuk-cookie-banner__content">
-          <p>We use some essential cookies to make our services work.</p>
-          <p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
+          <p class="govuk-body">We use some essential cookies to make our services work.</p>
+          <p class="govuk-body">We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
         </div>
       </div>
     </div>
@@ -23,7 +23,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
-          <p>You've accepted analytics cookies. You can <a class="govuk-link" href="{{CHS_URL}}/help/cookies">change your cookie settings</a> at any time.</p>
+          <p class="govuk-body">You've accepted analytics cookies. You can <a class="govuk-link" href="{{CHS_URL}}/help/cookies">change your cookie settings</a> at any time.</p>
         </div>
       </div>
     </div>
@@ -37,7 +37,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
-          <p>You've rejected analytics cookies. You can <a class="govuk-link" href="{{CHS_URL}}/help/cookies">change your cookie settings</a> at any time.</p>
+          <p class="govuk-body">You've rejected analytics cookies. You can <a class="govuk-link" href="{{CHS_URL}}/help/cookies">change your cookie settings</a> at any time.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Found when testing, with later versions of GOV.UK Frontend the internal elements of the cookie banner are not styled automatically so their respective classes must be applied manually.