### PR TITLE
GRUB 4 - Update footer to match main landing page

### DIFF
--- a/src/views/base.html
+++ b/src/views/base.html
@@ -64,6 +64,7 @@
     <a id="feedback-link" href="../help/feedback?sourceurl={{ FEEDBACK_SOURCE }}" class="secondary-customer-insights govuk-link" target="_blank">Is there anything wrong with this page?<span class="hidden">(link opens a new window)</span></a>
   </div>
   {{ govukFooter({
+      classes: "app-footer",
       meta: {
         items: [
           {
@@ -89,7 +90,8 @@
             href: "https://developer.companieshouse.gov.uk/api/docs/",
             text: "Developers"
           }
-        ]
+        ],
+        html: 'Built by <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/companies-house">Companies House</a>'
       }
     }) }}
 {% endblock %}

--- a/static/app.scss
+++ b/static/app.scss
@@ -322,3 +322,15 @@ border-left: 4px solid #1d70b8;
       display: none;
     }
   }
+
+/* GOV.UK Footer overrides */
+/* Remove the OGL licencing section */
+.app-footer {
+    .govuk-footer__licence-logo,
+    .govuk-footer__licence-description {
+        display: none;
+    }
+    .govuk-footer__meta-custom {
+        margin-bottom: 0;
+    }
+}


### PR DESCRIPTION
This is likely something we'll want to do it across many of our applications so I'm thinking of the best way to abstract this but for now this will work.

Removes the OGL content licence from the footer.