### PR TITLE
GURB-4 - No longer serve all.js

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -119,7 +119,6 @@ app.use("/search-assets/static", express.static(APP_ASSETS_PATH));
 env.addGlobal("CSS_URL", "/search-assets/static/app.css");
 env.addGlobal("ALPHABETICAL_SEARCH", "/search-assets/static/alphabetical_search.css");
 env.addGlobal("MATCHER", "/search-assets/static/js/matcher.js");
-env.addGlobal("ALL", "/search-assets/static/js/all.js");
 env.addGlobal("MOBILE_MENU", "/search-assets/static/js/mobile-menu.js");
 
 // apply our default router to /

--- a/src/views/base.html
+++ b/src/views/base.html
@@ -25,7 +25,6 @@
     <!--<![endif]-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="{{ MATCHER }}"></script>
-    <script src="{{ ALL }}"></script>
     <script src="{{ MOBILE_MENU }}"></script>
 
     <div id="templateName" data-id='{{templateName}}' hidden></div>


### PR DESCRIPTION
In 1f91886303daa392f3574907da95ee2c0d7c4e2d we removed copying the all.js file from GOV.UK Frontend into the application's dist since we were now loading it from the CDN.

I missed these couple of references, which are no longer needed and can be removed.