### PR TITLE
LP-2083 Matomo events when searching Limited Partnerships

### DIFF
--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -90,9 +90,13 @@ const wrappedRoute = async (req: Request, res: Response) => {
     const numberOfPages: number = Math.ceil(maximumDisplayableResults / 20);
     const pagingRange = getPagingRange(page, numberOfPages);
     const partialHref: string = buildPagingUrl(advancedSearchParams, incorporationDates, dissolvedDates);
-    const downloadResultsMatomoEventId: string = advancedSearchParams.companyType === "registered-overseas-entity"
-        ? "advanced-search-results-page-roe-download-results"
-        : "advanced-search-results-page-download-results";
+
+    let downloadResultsMatomoEventId: string = "advanced-search-results-page-download-results";
+    if (advancedSearchParams.companyType === "registered-overseas-entity") {
+        downloadResultsMatomoEventId = "advanced-search-results-page-roe-download-results";
+    } else if (advancedSearchParams.companyType === "limited-partnership") {
+        downloadResultsMatomoEventId = "advanced-search-results-page-limited-partnership-download-results";
+    }
 
     return res.render(templatePaths.ADVANCED_SEARCH_RESULTS, {
         ...dissolvedDates,

--- a/src/controllers/advanced-search/search.controller.ts
+++ b/src/controllers/advanced-search/search.controller.ts
@@ -90,13 +90,7 @@ const wrappedRoute = async (req: Request, res: Response) => {
     const numberOfPages: number = Math.ceil(maximumDisplayableResults / 20);
     const pagingRange = getPagingRange(page, numberOfPages);
     const partialHref: string = buildPagingUrl(advancedSearchParams, incorporationDates, dissolvedDates);
-
-    let downloadResultsMatomoEventId: string = "advanced-search-results-page-download-results";
-    if (advancedSearchParams.companyType === "registered-overseas-entity") {
-        downloadResultsMatomoEventId = "advanced-search-results-page-roe-download-results";
-    } else if (advancedSearchParams.companyType === "limited-partnership") {
-        downloadResultsMatomoEventId = "advanced-search-results-page-limited-partnership-download-results";
-    }
+    const downloadResultsMatomoEventId: string = getDownloadResultsMatomoEventId(advancedSearchParams.companyType);
 
     return res.render(templatePaths.ADVANCED_SEARCH_RESULTS, {
         ...dissolvedDates,
@@ -118,6 +112,16 @@ const wrappedRoute = async (req: Request, res: Response) => {
         ...basketLink,
         ...pageHeader
     });
+};
+
+const getDownloadResultsMatomoEventId = (companyType: string | null): string => {
+    if (companyType === "registered-overseas-entity") {
+        return "advanced-search-results-page-roe-download-results";
+    }
+    if (companyType === "limited-partnership") {
+        return "advanced-search-results-page-limited-partnership-download-results";
+    }
+    return "advanced-search-results-page-download-results";
 };
 
 export default [...advancedSearchValidationRules, route];

--- a/src/views/advanced-search/index.html
+++ b/src/views/advanced-search/index.html
@@ -86,7 +86,7 @@
             </div>
 
             <div class='govuk-checkboxes__item'>
-              <input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership'>
+              <input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' data-event-id='advanced-search-limited-partnership-selected-start-page'>
               <label class='govuk-label govuk-checkboxes__label' for='limited-partnership'>
                 Limited partnership
               </label>

--- a/src/views/advanced-search/results.html
+++ b/src/views/advanced-search/results.html
@@ -541,7 +541,7 @@
                     </div>
 
                     <div class='govuk-checkboxes__item'>
-                        <input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' {{ selectedTypeCheckboxes.limitedPartnership }}>
+                        <input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' {{ selectedTypeCheckboxes.limitedPartnership }} data-event-id='advanced-search-limited-partnership-selected-results-page'>
                         <label class='govuk-label govuk-checkboxes__label' for='limited-partnership'>
                 Limited partnership
               </label>

--- a/test/controllers/advanced-search/index.test.ts
+++ b/test/controllers/advanced-search/index.test.ts
@@ -87,6 +87,15 @@ describe("advanced search search.controller.test", () => {
             chai.expect(resp.text).to.contain("Dissolved date");
             chai.expect(resp.text).to.contain("We can only show companies dissolved since 01/01/2010.");
         });
+
+        it("should set correct data event ids for company type options", async () => {
+            const resp = await chai.request(testApp)
+                .get("/advanced-search");
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("<input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' data-event-id='advanced-search-limited-partnership-selected-start-page'>");
+            chai.expect(resp.text).to.contain("<input class='govuk-checkboxes__input' id='registered-overseas-entity' name='type' type='checkbox' value='registered-overseas-entity' data-event-id='advanced-search-overseas-entity-selected-start-page'>");
+        });
     });
 
     describe("populate feedback link with the advanced-search source url", () => {

--- a/test/controllers/advanced-search/search.controller.test.ts
+++ b/test/controllers/advanced-search/search.controller.test.ts
@@ -350,7 +350,7 @@ describe("advanced search search.controller.test", () => {
                 .get("/advanced-search/get-results?type=limited-partnership");
 
             chai.expect(resp.status).to.equal(200);
-            chai.expect(resp.text).to.contain("<input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' checked>");
+            chai.expect(resp.text).to.contain("<input class='govuk-checkboxes__input' id='limited-partnership' name='type' type='checkbox' value='limited-partnership' checked data-event-id='advanced-search-limited-partnership-selected-results-page'>");
         });
 
         it("should display the company subtypes search term is checked", async () => {
@@ -949,6 +949,33 @@ describe("advanced search search.controller.test", () => {
     });
 
     describe("Download button", () => {
+        const downloadButtonEventTypeTestCases = [
+            {
+                companyType: "registered-overseas-entity",
+                expectedEventId: "advanced-search-results-page-roe-download-results"
+            },
+            {
+                companyType: "limited-partnership",
+                expectedEventId: "advanced-search-results-page-limited-partnership-download-results"
+            }
+        ];
+
+        for (const { companyType, expectedEventId } of downloadButtonEventTypeTestCases) {
+            it(`should set correct data event id on download button when company type is ${companyType}`, async () => {
+                const data = Promise.resolve(mockUtils.getDummyAdvancedCompanyResource("test", 1));
+                (await data).items[0].company_type = companyType;
+
+                getCompanyItemStub = sandbox.stub(apiClient, "getAdvancedCompanies")
+                    .returns(data);
+
+                const resp = await chai.request(testApp)
+                    .get(`/advanced-search/get-results?companyNameIncludes=test&type=${companyType}`);
+
+                chai.expect(resp.status).to.equal(200);
+                chai.expect(resp.text).to.contain(`<button class="govuk-button" data-module="govuk-button" data-event-id=${expectedEventId}>\n                    Download results\n                    </button>`);
+            });
+        }
+
         it("should show an active download button", async () => {
             getCompanyItemStub = sandbox.stub(apiClient, "getAdvancedCompanies")
                 .returns(Promise.resolve(mockUtils.getDummyAdvancedCompanyResource("test", 50)));


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-2083

* New events written to Matomo when using GCI Advanced Search screens to find Limited Partnerships
* Both when selecting LPs and downloading results for them
* Unit tests added and updated